### PR TITLE
docs: tell agents to use GITHUB_PAT for GitHub writes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Agent instructions
+
+## GitHub operations
+
+When modifying GitHub issues, pull requests, comments, or Projects from this repository, use the `GITHUB_PAT` environment secret as the GitHub token.
+
+Examples:
+
+- `GH_TOKEN="$GITHUB_PAT" gh issue view 2 --repo TbLtzk/q-client`
+- `GH_TOKEN="$GITHUB_PAT" gh api graphql ...`
+
+Do not rely on the default `gh` authentication for GitHub writes. It may only have read or metadata access.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,14 @@ Examples:
 
 Do not rely on the default `gh` authentication for GitHub writes. It may only have read or metadata access.
 
+## Starting issues
+
+When an agent is told to work on an issue:
+
+- If the issue is not in `Ready`, explain that the issue is not marked as ready and ask whether to start anyway.
+- If the issue is already assigned to someone else, explain who is working on it and ask whether to reassign it and start anyway.
+- If the issue is in `Ready`, acknowledge it, assign it to the agent where possible, move it to `In progress`, and start working on the issue.
+
 ## Completing issues
 
 When an agent considers its assigned issue complete:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,3 +10,11 @@ Examples:
 - `GH_TOKEN="$GITHUB_PAT" gh api graphql ...`
 
 Do not rely on the default `gh` authentication for GitHub writes. It may only have read or metadata access.
+
+## Completing issues
+
+When an agent considers its assigned issue complete:
+
+- Mark the pull request as ready for review.
+- Comment on the issue with a link to the pull request, or explain why the issue is complete without a pull request.
+- Move the issue to `In review` on the project board.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add `AGENTS.md` guidance for future agents to use the `GITHUB_PAT` environment secret when modifying GitHub issues, pull requests, comments, or Projects.
- Include examples for `gh` and GraphQL usage, and warn against relying on the default `gh` auth for writes.
- Document issue start behavior: handle not-ready issues, already-assigned issues, and Ready issues.
- Document the issue completion handoff: mark PR ready, comment on the issue with the PR link or no-PR rationale, and move the issue to `In review`.

### Testing
- Documentation-only change; verified the file contents directly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a8ad1fb-9353-4369-b5d1-90d90b06a6e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a8ad1fb-9353-4369-b5d1-90d90b06a6e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

