### PR TITLE
Complete external L0 signed governance ingestion

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1335,7 +1335,7 @@ func setHTTP(ctx *cli.Context, cfg *node.Config) {
 	}
 }
 
-// Prevents opening gov api as external endpoint
+// Prevents opening private gov api as an external endpoint while allowing govPub.
 func filterProtectedAPIs(ret []string, ns string, gcmodevalue string) []string {
 	res := []string{}
 	for _, api := range ret {

--- a/cmd/utils/flags_test.go
+++ b/cmd/utils/flags_test.go
@@ -65,3 +65,23 @@ func Test_SplitTagsFlag(t *testing.T) {
 		})
 	}
 }
+
+func TestFilterProtectedAPIsBlocksPrivateGovOnly(t *testing.T) {
+	t.Parallel()
+
+	got := filterProtectedAPIs([]string{"eth", " gov ", "govPub", "web3"}, "http", ArchiveValue)
+	want := []string{"eth", "govPub", "web3"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("filterProtectedAPIs() = %v, want %v", got, want)
+	}
+}
+
+func TestFilterProtectedAPIsAllowsGovPubOnWebSocket(t *testing.T) {
+	t.Parallel()
+
+	got := filterProtectedAPIs([]string{"govPub"}, "ws", ArchiveValue)
+	want := []string{"govPub"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("filterProtectedAPIs() = %v, want %v", got, want)
+	}
+}

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -798,6 +798,18 @@ func (ec *Client) GetProposedRootList(ctx context.Context) (governance.RootList,
 	return res, err
 }
 
+func (ec *Client) SubmitSignedRootList(ctx context.Context, list common.RootList) (common.Hash, error) {
+	var res common.Hash
+	err := ec.c.CallContext(ctx, &res, "govPub_submitSignedRootList", list)
+	return res, err
+}
+
+func (ec *Client) SubmitSignedExclusionList(ctx context.Context, list common.ValidatorExclusionList) (common.Hash, error) {
+	var res common.Hash
+	err := ec.c.CallContext(ctx, &res, "govPub_submitSignedExclusionList", list)
+	return res, err
+}
+
 func toBlockNumArg(number *big.Int) string {
 	if number == nil {
 		return "latest"

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -179,6 +179,59 @@ func TestToFilterArg(t *testing.T) {
 	}
 }
 
+type governanceSubmissionTestAPI struct {
+	rootList      common.RootList
+	exclusionList common.ValidatorExclusionList
+}
+
+func (api *governanceSubmissionTestAPI) SubmitSignedRootList(list common.RootList) common.Hash {
+	api.rootList = list
+	return list.Hash
+}
+
+func (api *governanceSubmissionTestAPI) SubmitSignedExclusionList(list common.ValidatorExclusionList) common.Hash {
+	api.exclusionList = list
+	return list.Hash
+}
+
+func TestGovernanceSubmissionWrappers(t *testing.T) {
+	server := rpc.NewServer()
+	api := new(governanceSubmissionTestAPI)
+	if err := server.RegisterName("govPub", api); err != nil {
+		t.Fatalf("failed to register govPub API: %v", err)
+	}
+	client := NewClient(rpc.DialInProc(server))
+	defer client.Close()
+
+	rootList := common.RootList{
+		Timestamp:  1,
+		Nodes:      []common.Address{common.HexToAddress("0x1")},
+		Hash:       common.HexToHash("0x1234"),
+		Signatures: [][]byte{{1, 2, 3}},
+	}
+	rootHash, err := client.SubmitSignedRootList(context.Background(), rootList)
+	if err != nil {
+		t.Fatalf("SubmitSignedRootList returned error: %v", err)
+	}
+	if rootHash != rootList.Hash || !reflect.DeepEqual(api.rootList, rootList) {
+		t.Fatalf("unexpected root submission result hash=%s list=%v", rootHash.Hex(), api.rootList)
+	}
+
+	exclusionList := common.ValidatorExclusionList{
+		Timestamp:  2,
+		Validators: []common.ExcludedValidator{{Address: common.HexToAddress("0x2"), Block: 10, EndBlock: 20}},
+		Hash:       common.HexToHash("0x5678"),
+		Signatures: [][]byte{{4, 5, 6}},
+	}
+	exclusionHash, err := client.SubmitSignedExclusionList(context.Background(), exclusionList)
+	if err != nil {
+		t.Fatalf("SubmitSignedExclusionList returned error: %v", err)
+	}
+	if exclusionHash != exclusionList.Hash || !reflect.DeepEqual(api.exclusionList, exclusionList) {
+		t.Fatalf("unexpected exclusion submission result hash=%s list=%v", exclusionHash.Hex(), api.exclusionList)
+	}
+}
+
 var (
 	testKey, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 	testAddr    = crypto.PubkeyToAddress(testKey.PublicKey)

--- a/governance/api.go
+++ b/governance/api.go
@@ -155,6 +155,33 @@ func (a *GovernanceAPI) ProposeExclusionListUpdate(list common.ValidatorExclusio
 	return set.hash, nil
 }
 
+func (a *GovernancePublicAPI) SubmitSignedExclusionList(list common.ValidatorExclusionList) (common.Hash, error) {
+	set, err := newExclusionSet(&list)
+	if err != nil {
+		return common.Hash{}, errors.Wrap(err, "invalid signed exclusion list")
+	}
+	if len(set.signers) == 0 {
+		return common.Hash{}, errors.New("signed exclusion list has no signatures")
+	}
+
+	rm := a.gov.RootManager
+	before, err := rm.snapshotExclusionListImport(set)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	if err := a.gov.handler.importExclusionList(&list); err != nil {
+		return common.Hash{}, err
+	}
+
+	after := rm.exclusionListImportSnapshot(set.hash)
+	if !after.changedFrom(before) {
+		return common.Hash{}, errors.New("signed exclusion list was not accepted")
+	}
+
+	return set.hash, nil
+}
+
 func (a *GovernanceAPI) AcceptQuarantinedExclusionList(hash *common.Hash) error {
 	return a.gov.RootManager.acceptQuarantinedExclusionSet(hash)
 }

--- a/governance/api.go
+++ b/governance/api.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"gitlab.com/q-dev/q-client/common"
 	"gitlab.com/q-dev/q-client/log"
+	"gitlab.com/q-dev/q-client/rlp"
 )
 
 // GovernanceAPI. (shouldn't be opened via http/ws)
@@ -49,6 +50,10 @@ func (a *GovernancePublicAPI) OnchainRootList() *RootList {
 }
 
 func (a *GovernancePublicAPI) SubmitSignedRootList(list common.RootList) (common.Hash, error) {
+	if err := a.gov.RootManager.validatePublicSubmissionAllowed(list); err != nil {
+		return common.Hash{}, err
+	}
+
 	set, err := newRootSet(&list)
 	if err != nil {
 		return common.Hash{}, errors.Wrap(err, "invalid signed root list")
@@ -156,6 +161,10 @@ func (a *GovernanceAPI) ProposeExclusionListUpdate(list common.ValidatorExclusio
 }
 
 func (a *GovernancePublicAPI) SubmitSignedExclusionList(list common.ValidatorExclusionList) (common.Hash, error) {
+	if err := a.gov.RootManager.validatePublicSubmissionAllowed(list); err != nil {
+		return common.Hash{}, err
+	}
+
 	set, err := newExclusionSet(&list)
 	if err != nil {
 		return common.Hash{}, errors.Wrap(err, "invalid signed exclusion list")
@@ -180,6 +189,26 @@ func (a *GovernancePublicAPI) SubmitSignedExclusionList(list common.ValidatorExc
 	}
 
 	return set.hash, nil
+}
+
+func (s *RootManager) validatePublicSubmissionAllowed(list interface{}) error {
+	if s.DisablePublicSubmission {
+		return errPublicGovernanceSubmissionDisabled
+	}
+
+	size, _, err := rlp.EncodeToReader(list)
+	if err != nil {
+		return err
+	}
+	if size > protocolMaxMsgSize {
+		return errMsgTooLarge
+	}
+
+	return nil
+}
+
+func (s *RootManager) isProposalQuotaDisabled() bool {
+	return s.ProposalQuotaMax == 0
 }
 
 func (a *GovernanceAPI) AcceptQuarantinedExclusionList(hash *common.Hash) error {

--- a/governance/api.go
+++ b/governance/api.go
@@ -48,6 +48,33 @@ func (a *GovernancePublicAPI) OnchainRootList() *RootList {
 	return newRootList(a.gov.RootManager.getOnchainRootSet(true))
 }
 
+func (a *GovernancePublicAPI) SubmitSignedRootList(list common.RootList) (common.Hash, error) {
+	set, err := newRootSet(&list)
+	if err != nil {
+		return common.Hash{}, errors.Wrap(err, "invalid signed root list")
+	}
+	if set == nil || len(set.signers) == 0 {
+		return common.Hash{}, errors.New("signed root list has no signatures")
+	}
+
+	rm := a.gov.RootManager
+	before, err := rm.snapshotRootListImport(set)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	if err := a.gov.handler.importRootList(&list); err != nil {
+		return common.Hash{}, err
+	}
+
+	after := rm.rootListImportSnapshot(set.hash)
+	if !after.changedFrom(before) {
+		return common.Hash{}, errors.New("signed root list was not accepted")
+	}
+
+	return set.hash, nil
+}
+
 func (a *GovernanceAPI) ProposeRootListUpdate(list common.RootList, force bool) (common.Hash, error) {
 	set, err := newRootSet(&list)
 	if err != nil {

--- a/governance/handler.go
+++ b/governance/handler.go
@@ -353,7 +353,7 @@ func (h *handler) runPeer(p *peer) error {
 	} {
 		our, their := set.our, set.their
 		if shouldPropagateExcl(our, their, rm.active) {
-			if err = h.handleExclusionSet(p, their); err != nil {
+			if err = h.importExclusionSet(p.id, their, true); err != nil {
 				return err
 			}
 		}
@@ -770,15 +770,22 @@ func (h *handler) handleExclusionList(p *peer, msg p2p.Msg) error {
 		return err
 	}
 
-	received, err := newExclusionSet(&list)
+	return h.importExclusionListFrom(p.id, &list, true)
+}
+
+func (h *handler) importExclusionList(list *common.ValidatorExclusionList) error {
+	return h.importExclusionListFrom("", list, false)
+}
+
+func (h *handler) importExclusionListFrom(fromID string, list *common.ValidatorExclusionList, signLocal bool) error {
+	received, err := newExclusionSet(list)
 	if err != nil {
 		return err
 	}
-
-	return h.handleExclusionSet(p, received)
+	return h.importExclusionSet(fromID, received, signLocal)
 }
 
-func (h *handler) handleExclusionSet(p *peer, received *exclusionSet) error {
+func (h *handler) importExclusionSet(fromID string, received *exclusionSet, signLocal bool) error {
 	if received.blockRanges == nil && received.addrToBlock != nil {
 		for address, blockAddress := range received.addrToBlock {
 			received.blockRanges[address] = []common.BlockRange{
@@ -815,7 +822,7 @@ func (h *handler) handleExclusionSet(p *peer, received *exclusionSet) error {
 			received.mergeSignatures(rm.desiredExSet.hash, rm.desiredExSet.signers)
 		}
 
-		if rm.isRootNode(false) {
+		if signLocal && rm.isRootNode(false) {
 			rm.signExclusionSet(received)
 		}
 
@@ -825,7 +832,7 @@ func (h *handler) handleExclusionSet(p *peer, received *exclusionSet) error {
 	case rm.activeExSet != nil && rm.activeExSet.hash == received.hash:
 		// On very start of the node account can be not unlocked, so isRootNode can return false
 		signatureAdded := false // In case when alias changed
-		if rm.isRootNode(false) {
+		if signLocal && rm.isRootNode(false) {
 			signatureAdded = rm.signExclusionSet(rm.activeExSet)
 		}
 		newSignatures := rm.activeExSet.mergeSignatures(received.hash, received.signers)
@@ -833,8 +840,8 @@ func (h *handler) handleExclusionSet(p *peer, received *exclusionSet) error {
 			return nil
 		}
 
-		log.Debug("Received new exclusion list signatures", "from", p.id, "singers", toSigners(newSignatures))
-		h.exEventCh <- &exclusionSetEvent{fromID: p.id, set: rm.activeExSet.copy()}
+		log.Debug("Received new exclusion list signatures", "from", fromID, "singers", toSigners(newSignatures))
+		h.exEventCh <- &exclusionSetEvent{fromID: fromID, set: rm.activeExSet.copy()}
 		rm.db.saveActiveExclusionSet(rm.activeExSet)
 	case rm.desiredExSet != nil && rm.desiredExSet.hash == received.hash:
 		newSignatures := rm.desiredExSet.mergeSignatures(received.hash, received.signers)
@@ -842,9 +849,9 @@ func (h *handler) handleExclusionSet(p *peer, received *exclusionSet) error {
 			return nil
 		}
 
-		log.Debug("Received new desired exclusion list signatures", "from", p.id, "singers", toSigners(newSignatures))
+		log.Debug("Received new desired exclusion list signatures", "from", fromID, "singers", toSigners(newSignatures))
 		if !rm.getActiveRootSet(true).isEnoughExSetSignatures(rm.desiredExSet) {
-			h.exEventCh <- &exclusionSetEvent{fromID: p.id, set: rm.desiredExSet}
+			h.exEventCh <- &exclusionSetEvent{fromID: fromID, set: rm.desiredExSet}
 			rm.db.saveDesiredExclusionSet(rm.desiredExSet)
 			return nil
 		}
@@ -859,7 +866,7 @@ func (h *handler) handleExclusionSet(p *peer, received *exclusionSet) error {
 		}
 
 		if !rm.isAcceptableExclusionSet(rm.proposedExSet) {
-			h.exEventCh <- &exclusionSetEvent{fromID: p.id, set: rm.proposedExSet.copy()}
+			h.exEventCh <- &exclusionSetEvent{fromID: fromID, set: rm.proposedExSet.copy()}
 			rm.db.saveProposedExclusionSet(rm.proposedExSet)
 			return nil
 		}

--- a/governance/handler.go
+++ b/governance/handler.go
@@ -337,7 +337,7 @@ func (h *handler) runPeer(p *peer) error {
 	} {
 		our, their := set.our, set.their
 		if shouldPropagateRoots(our, their, rm.active) {
-			if err = h.handleRootSet(p, their); err != nil {
+			if err = h.importRootSet(p.id, their, true); err != nil {
 				return err
 			}
 		}
@@ -514,13 +514,7 @@ func (h *handler) handleRootListMsg(p *peer, msg p2p.Msg) error {
 		return err
 	}
 
-	received, err := newRootSet(&list)
-	if err != nil {
-		return err
-	}
-	received.updateAliases(h.rootManager.getAliasesOfRoots(received.rootAddresses))
-
-	return h.handleRootSet(p, received)
+	return h.importRootListFrom(p.id, &list, true)
 }
 
 func (h *handler) handleApprovalMsg(p *peer, msg p2p.Msg) error {
@@ -662,10 +656,24 @@ func (h *handler) handleConstitutionFilesMsg(p *peer, msg p2p.Msg) error {
 	return nil
 }
 
-func (h *handler) handleRootSet(p *peer, received *rootSet) error {
+func (h *handler) importRootList(list *common.RootList) error {
+	return h.importRootListFrom("", list, false)
+}
+
+func (h *handler) importRootListFrom(fromID string, list *common.RootList, signLocal bool) error {
+	received, err := newRootSet(list)
+	if err != nil {
+		return err
+	}
+	return h.importRootSet(fromID, received, signLocal)
+}
+
+func (h *handler) importRootSet(fromID string, received *rootSet, signLocal bool) error {
 	rm := h.rootManager
 	rm.rootLock.Lock()
 	defer rm.rootLock.Unlock()
+
+	received.updateAliases(rm.getAliasesOfRoots(received.rootAddresses))
 
 	// Check if the received root set is acceptable (spam protection)
 	// Skip this check if the received root set is the same as the active one
@@ -683,7 +691,7 @@ func (h *handler) handleRootSet(p *peer, received *rootSet) error {
 
 	switch {
 	case rm.active.isAcceptable(received) && (rm.desired == nil || rm.desired.hash != received.hash):
-		if rm.isRootNode(false) {
+		if signLocal && rm.isRootNode(false) {
 			rm.signRootSet(received)
 		}
 
@@ -691,7 +699,7 @@ func (h *handler) handleRootSet(p *peer, received *rootSet) error {
 
 		h.rootEventCh <- &rootSetEvent{set: received}
 	case rm.active.hash == received.hash:
-		if rm.isRootNode(false) {
+		if signLocal && rm.isRootNode(false) {
 			rm.signRootSet(rm.active)
 		}
 		newSignatures := rm.active.mergeSignatures(received.hash, received.signers)
@@ -699,8 +707,8 @@ func (h *handler) handleRootSet(p *peer, received *rootSet) error {
 			return nil
 		}
 
-		log.Debug("Received active root list signatures", "from", p.id, "signers", toSigners(newSignatures))
-		h.rootEventCh <- &rootSetEvent{fromID: p.id, set: rm.active.copy()}
+		log.Debug("Received active root list signatures", "from", fromID, "signers", toSigners(newSignatures))
+		h.rootEventCh <- &rootSetEvent{fromID: fromID, set: rm.active.copy()}
 
 		rm.db.saveActiveRootSet(rm.active)
 	case rm.desired != nil && rm.desired.hash == received.hash:
@@ -709,9 +717,9 @@ func (h *handler) handleRootSet(p *peer, received *rootSet) error {
 			return nil
 		}
 
-		log.Debug("Received desired root list signatures", "from", p.id, "signers", toSigners(newSignatures))
+		log.Debug("Received desired root list signatures", "from", fromID, "signers", toSigners(newSignatures))
 		if !rm.active.isAcceptable(rm.desired) {
-			h.rootEventCh <- &rootSetEvent{fromID: p.id, set: rm.desired.copy()}
+			h.rootEventCh <- &rootSetEvent{fromID: fromID, set: rm.desired.copy()}
 			rm.db.saveDesiredRootSet(rm.desired)
 			return nil
 		}
@@ -724,9 +732,9 @@ func (h *handler) handleRootSet(p *peer, received *rootSet) error {
 			return nil
 		}
 
-		log.Debug("Received proposed root list signatures", "from", p.id, "signers", toSigners(newSignatures))
+		log.Debug("Received proposed root list signatures", "from", fromID, "signers", toSigners(newSignatures))
 		if !rm.active.isAcceptable(rm.proposed) {
-			h.rootEventCh <- &rootSetEvent{fromID: p.id, set: rm.proposed.copy()}
+			h.rootEventCh <- &rootSetEvent{fromID: fromID, set: rm.proposed.copy()}
 			rm.db.saveProposedRootSet(rm.proposed)
 			return nil
 		}
@@ -738,7 +746,7 @@ func (h *handler) handleRootSet(p *peer, received *rootSet) error {
 		if len(signers) == 0 {
 			log.Debug("Ignoring proposed root list: not signed by any known root node",
 				"hash", received.hash.Hex(),
-				"from", p.id)
+				"from", fromID)
 			return nil
 		}
 
@@ -749,7 +757,7 @@ func (h *handler) handleRootSet(p *peer, received *rootSet) error {
 
 		rm.proposed = received
 		rm.db.saveProposedRootSet(rm.proposed)
-		h.rootEventCh <- &rootSetEvent{fromID: p.id, set: received}
+		h.rootEventCh <- &rootSetEvent{fromID: fromID, set: received}
 		log.Warn("Received a new proposed root list", "hash", received.hash.Hex(), "timestamp", received.timestamp)
 	}
 

--- a/governance/handler.go
+++ b/governance/handler.go
@@ -433,6 +433,89 @@ func areSignersEqual(ourSigners, theirSigners map[common.Address][]byte) bool {
 	return true
 }
 
+type rootListImportSnapshot struct {
+	activeSigners   int
+	desiredSigners  int
+	proposedSigners int
+
+	activeHash   common.Hash
+	desiredHash  common.Hash
+	proposedHash common.Hash
+}
+
+func (s rootListImportSnapshot) changedFrom(before rootListImportSnapshot) bool {
+	return s.activeHash != before.activeHash ||
+		s.desiredHash != before.desiredHash ||
+		s.proposedHash != before.proposedHash ||
+		s.activeSigners != before.activeSigners ||
+		s.desiredSigners != before.desiredSigners ||
+		s.proposedSigners != before.proposedSigners
+}
+
+func (s *RootManager) snapshotRootListImport(set *rootSet) (rootListImportSnapshot, error) {
+	if set == nil {
+		return rootListImportSnapshot{}, errProposedRootListEmpty
+	}
+
+	s.rootLock.Lock()
+	defer s.rootLock.Unlock()
+
+	set.updateAliases(s.getAliasesOfRoots(set.rootAddresses))
+	if len(s.active.knownSigners(set.signers)) == 0 {
+		return rootListImportSnapshot{}, errors.New("signed root list has no active root signatures")
+	}
+	if set.hash != s.active.hash && set.timestamp <= s.active.timestamp {
+		return rootListImportSnapshot{}, errProposedRootListObsolete
+	}
+	if s.desired != nil && set.hash != s.desired.hash && set.timestamp <= s.desired.timestamp {
+		return rootListImportSnapshot{}, errProposedRootListObsolete
+	}
+	if s.proposed != nil && set.hash != s.proposed.hash && set.timestamp <= s.proposed.timestamp {
+		return rootListImportSnapshot{}, errProposedRootListObsolete
+	}
+	if s.active == nil || s.active.hash != set.hash {
+		exceeded, err := s.isSetQuotaExceeded(set)
+		if err != nil {
+			return rootListImportSnapshot{}, err
+		}
+		if exceeded {
+			return rootListImportSnapshot{}, errors.New("root list quota exceeded")
+		}
+	}
+
+	return s.rootListImportSnapshotLocked(set.hash), nil
+}
+
+func (s *RootManager) rootListImportSnapshot(hash common.Hash) rootListImportSnapshot {
+	s.rootLock.Lock()
+	defer s.rootLock.Unlock()
+
+	return s.rootListImportSnapshotLocked(hash)
+}
+
+func (s *RootManager) rootListImportSnapshotLocked(hash common.Hash) rootListImportSnapshot {
+	snapshot := rootListImportSnapshot{}
+	if s.active != nil {
+		snapshot.activeHash = s.active.hash
+		if s.active.hash == hash {
+			snapshot.activeSigners = len(s.active.signers)
+		}
+	}
+	if s.desired != nil {
+		snapshot.desiredHash = s.desired.hash
+		if s.desired.hash == hash {
+			snapshot.desiredSigners = len(s.desired.signers)
+		}
+	}
+	if s.proposed != nil {
+		snapshot.proposedHash = s.proposed.hash
+		if s.proposed.hash == hash {
+			snapshot.proposedSigners = len(s.proposed.signers)
+		}
+	}
+	return snapshot
+}
+
 func (h *handler) propagateRootSet(set *rootSet) {
 	if set != nil {
 		h.rootEventCh <- &rootSetEvent{set: set}

--- a/governance/handler.go
+++ b/governance/handler.go
@@ -474,7 +474,7 @@ func (s *RootManager) snapshotRootListImport(set *rootSet) (rootListImportSnapsh
 		return rootListImportSnapshot{}, errProposedRootListObsolete
 	}
 	if s.active == nil || s.active.hash != set.hash {
-		exceeded, err := s.isSetQuotaExceeded(set)
+		exceeded, err := s.isSetQuotaExceededDryRun(set)
 		if err != nil {
 			return rootListImportSnapshot{}, err
 		}
@@ -567,6 +567,16 @@ func (s *RootManager) snapshotExclusionListImport(set *exclusionSet) (exclusionL
 
 	if s.getActiveRootSet(true).isEnoughExSetSignatures(set) && s.exclusionSetWouldQuarantine(set) {
 		return exclusionListImportSnapshot{}, errors.New("signed exclusion list would be quarantined")
+	}
+
+	if s.activeExSet == nil || s.activeExSet.hash != set.hash {
+		exceeded, err := s.isSetQuotaExceededDryRun(set)
+		if err != nil {
+			return exclusionListImportSnapshot{}, err
+		}
+		if exceeded {
+			return exclusionListImportSnapshot{}, errors.New("exclusion list quota exceeded")
+		}
 	}
 
 	return s.exclusionListImportSnapshotLocked(set.hash), nil

--- a/governance/handler.go
+++ b/governance/handler.go
@@ -516,6 +516,116 @@ func (s *RootManager) rootListImportSnapshotLocked(hash common.Hash) rootListImp
 	return snapshot
 }
 
+type exclusionListImportSnapshot struct {
+	activeSigners   int
+	desiredSigners  int
+	proposedSigners int
+	quarantineSize  int
+
+	activeHash   common.Hash
+	desiredHash  common.Hash
+	proposedHash common.Hash
+}
+
+func (s exclusionListImportSnapshot) changedFrom(before exclusionListImportSnapshot) bool {
+	return s.activeHash != before.activeHash ||
+		s.desiredHash != before.desiredHash ||
+		s.proposedHash != before.proposedHash ||
+		s.activeSigners != before.activeSigners ||
+		s.desiredSigners != before.desiredSigners ||
+		s.proposedSigners != before.proposedSigners ||
+		s.quarantineSize != before.quarantineSize
+}
+
+func (s *RootManager) snapshotExclusionListImport(set *exclusionSet) (exclusionListImportSnapshot, error) {
+	if set == nil {
+		return exclusionListImportSnapshot{}, errProposedExclusionListEmpty
+	}
+
+	if err := validateExclusionSetRanges(set); err != nil {
+		return exclusionListImportSnapshot{}, err
+	}
+
+	s.exLock.Lock()
+	defer s.exLock.Unlock()
+
+	s.active.aliases = s.getAliasesOfRoots(s.active.rootAddresses)
+	if len(s.getActiveRootSet(true).knownSigners(set.signers)) == 0 {
+		return exclusionListImportSnapshot{}, errors.New("signed exclusion list has no active root signatures")
+	}
+
+	obsoleteByActive := s.activeExSet != nil && set.hash != s.activeExSet.hash && set.timestamp <= s.activeExSet.timestamp
+	obsoleteByDesired := s.desiredExSet != nil && set.hash != s.desiredExSet.hash && set.timestamp <= s.desiredExSet.timestamp
+	obsoleteByProposed := s.proposedExSet != nil && set.hash != s.proposedExSet.hash && set.timestamp <= s.proposedExSet.timestamp
+	if obsoleteByActive || obsoleteByDesired || obsoleteByProposed {
+		return exclusionListImportSnapshot{}, errProposedExclusionListObsolete
+	}
+
+	if s.isExclusionSetInQuarantine(set) {
+		return exclusionListImportSnapshot{}, errors.New("signed exclusion list is quarantined")
+	}
+
+	if s.getActiveRootSet(true).isEnoughExSetSignatures(set) && s.exclusionSetWouldQuarantine(set) {
+		return exclusionListImportSnapshot{}, errors.New("signed exclusion list would be quarantined")
+	}
+
+	return s.exclusionListImportSnapshotLocked(set.hash), nil
+}
+
+func validateExclusionSetRanges(set *exclusionSet) error {
+	for address, ranges := range set.blockRanges {
+		for _, blockRange := range ranges {
+			if !blockRange.IsValid() {
+				return errors.Errorf("invalid exclusion list range for %s", address.Hex())
+			}
+		}
+	}
+	return nil
+}
+
+func (s *RootManager) exclusionSetWouldQuarantine(set *exclusionSet) bool {
+	if s.bc == nil {
+		return false
+	}
+	if len(set.addrToBlockRangeExclusiveDiff(s.activeExSet)) == 0 {
+		return false
+	}
+	return s.isExclusionSetMeetsQuarantineCriteria(set.earliestBlockFromDiff(s.activeExSet))
+}
+
+func (s *RootManager) exclusionListImportSnapshot(hash common.Hash) exclusionListImportSnapshot {
+	s.exLock.Lock()
+	defer s.exLock.Unlock()
+
+	return s.exclusionListImportSnapshotLocked(hash)
+}
+
+func (s *RootManager) exclusionListImportSnapshotLocked(hash common.Hash) exclusionListImportSnapshot {
+	snapshot := exclusionListImportSnapshot{}
+	if s.activeExSet != nil {
+		snapshot.activeHash = s.activeExSet.hash
+		if s.activeExSet.hash == hash {
+			snapshot.activeSigners = len(s.activeExSet.signers)
+		}
+	}
+	if s.desiredExSet != nil {
+		snapshot.desiredHash = s.desiredExSet.hash
+		if s.desiredExSet.hash == hash {
+			snapshot.desiredSigners = len(s.desiredExSet.signers)
+		}
+	}
+	if s.proposedExSet != nil {
+		snapshot.proposedHash = s.proposedExSet.hash
+		if s.proposedExSet.hash == hash {
+			snapshot.proposedSigners = len(s.proposedExSet.signers)
+		}
+	}
+	if qSets, err := s.db.getExclusionSetsFromQuarantine(); err == nil {
+		snapshot.quarantineSize = len(qSets)
+	}
+	return snapshot
+}
+
 func (h *handler) propagateRootSet(set *rootSet) {
 	if set != nil {
 		h.rootEventCh <- &rootSetEvent{set: set}

--- a/governance/handler_test.go
+++ b/governance/handler_test.go
@@ -489,6 +489,189 @@ func TestHandleExclusionSet(t *testing.T) {
 	}
 }
 
+func TestImportExclusionList(t *testing.T) {
+	tests := []struct {
+		name              string
+		initChain         bool
+		list              func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList
+		beforeImport      func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList)
+		assertAfterImport func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList)
+	}{
+		{
+			name: "known signer stores proposed list",
+			list: func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList {
+				return signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, 1, true, 6000)
+			},
+			assertAfterImport: func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList) {
+				if rm.proposedExSet == nil || rm.proposedExSet.hash != list.Hash {
+					t.Fatalf("expected proposed exclusion list %s, got %v", list.Hash.Hex(), rm.proposedExSet)
+				}
+				if rm.activeExSet.hash == list.Hash {
+					t.Fatal("single-signature exclusion list was upgraded")
+				}
+			},
+		},
+		{
+			name: "unknown signer is ignored",
+			list: func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList {
+				return signedExclusionList(t, nil, uint64(time.Now().Add(5*time.Minute).Unix()), 2, 1, true, 6000)
+			},
+			assertAfterImport: func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList) {
+				if rm.proposedExSet != nil {
+					t.Fatalf("expected unknown signer exclusion list to be ignored, got %s", rm.proposedExSet.hash.Hex())
+				}
+			},
+		},
+		{
+			name: "duplicate signature is ignored",
+			list: func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList {
+				list := signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, 1, true, 6000)
+				list.Signatures = append(list.Signatures, list.Signatures[0])
+				return list
+			},
+			assertAfterImport: func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList) {
+				if rm.proposedExSet == nil || rm.proposedExSet.hash != list.Hash {
+					t.Fatalf("expected proposed exclusion list %s, got %v", list.Hash.Hex(), rm.proposedExSet)
+				}
+				if len(rm.proposedExSet.signers) != 1 {
+					t.Fatalf("expected one unique signature, got %d", len(rm.proposedExSet.signers))
+				}
+			},
+		},
+		{
+			name: "obsolete timestamp is ignored",
+			list: func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList {
+				return signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, 1, true, 6000)
+			},
+			beforeImport: func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList) {
+				newer := signedExclusionList(t, rm, list.Timestamp+1, 2, 1, true, 7000)
+				set, err := newExclusionSet(&newer)
+				if err != nil {
+					t.Fatal(err)
+				}
+				rm.proposedExSet = set
+			},
+			assertAfterImport: func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList) {
+				if rm.proposedExSet == nil || rm.proposedExSet.hash == list.Hash {
+					t.Fatal("obsolete exclusion list replaced newer proposal")
+				}
+			},
+		},
+		{
+			name:      "threshold signatures upgrade active list",
+			initChain: true,
+			list: func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList {
+				return signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, defNumAccounts-1, true, 6000)
+			},
+			assertAfterImport: func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList) {
+				if rm.activeExSet == nil || rm.activeExSet.hash != list.Hash {
+					t.Fatalf("expected active exclusion list %s, got %v", list.Hash.Hex(), rm.activeExSet)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rm := newTestRootManager(t, false, true)
+			if tt.initChain {
+				bc := newTestChain(t, rm.RootManager)
+				defer bc.Stop()
+				rm.InitBlockChain(bc)
+			}
+			gov, err := New(rm.RootManager, tmpDirName(t))
+			if err != nil {
+				t.Fatalf("Failed to create Governance: %v", err)
+			}
+			if err := gov.Start(); err != nil {
+				t.Fatalf("Failed to start Governance: %v", err)
+			}
+
+			list := tt.list(t, rm)
+			if tt.beforeImport != nil {
+				tt.beforeImport(t, rm, list)
+			}
+			if err := gov.handler.importExclusionList(&list); err != nil {
+				t.Fatalf("importExclusionList returned error: %v", err)
+			}
+			tt.assertAfterImport(t, rm, list)
+		})
+	}
+}
+
+func TestImportExclusionListDoesNotRequireLocalSigning(t *testing.T) {
+	rm := newTestRootManager(t, true, false)
+	gov, err := New(rm.RootManager, tmpDirName(t))
+	if err != nil {
+		t.Fatalf("Failed to create Governance: %v", err)
+	}
+	if err := gov.Start(); err != nil {
+		t.Fatalf("Failed to start Governance: %v", err)
+	}
+
+	list := signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, 1, false, 6000)
+	if err := gov.handler.importExclusionList(&list); err != nil {
+		t.Fatalf("importExclusionList returned error: %v", err)
+	}
+
+	if rm.activeExSet != nil && rm.activeExSet.hash == list.Hash {
+		t.Fatal("import locally signed the exclusion list and upgraded it")
+	}
+	if rm.proposedExSet == nil || rm.proposedExSet.hash != list.Hash {
+		t.Fatalf("expected imported exclusion list to be proposed, got %v", rm.proposedExSet)
+	}
+	if len(rm.proposedExSet.signers) != 1 {
+		t.Fatalf("expected import to keep only supplied signature, got %d signatures", len(rm.proposedExSet.signers))
+	}
+}
+
+func TestImportExclusionListPreservesQuarantine(t *testing.T) {
+	earliestBlock := uint64(2)
+	rm := newTestRootManager(t, true, false)
+	bc := newTestChain(t, rm.RootManager)
+	defer bc.Stop()
+	rm.InitBlockChain(bc)
+	rm.setMaxRewindLimit(100)
+
+	list := rm.activeExSet.copy().makeList()
+	list.Timestamp++
+	list.Signatures = nil
+	list.Hash = common.Hash{}
+	list.Validators = append(list.Validators, common.ExcludedValidator{
+		Address: common.HexToAddress("0x2B01035cDa82a02fb135EBd68676Fa17FdcAD365"),
+		Block:   earliestBlock,
+	})
+	set, err := newExclusionSet(&list)
+	if err != nil {
+		t.Fatalf("Can't create new test exclusion set: %v", err)
+	}
+	rm.signExclusionSet(set)
+	list = set.makeList()
+
+	gov, err := New(rm.RootManager, tmpDirName(t))
+	if err != nil {
+		t.Fatalf("Failed to create Governance: %v", err)
+	}
+	if err := gov.Start(); err != nil {
+		t.Fatalf("Failed to start Governance: %v", err)
+	}
+
+	currentExclusionSet := rm.activeExSet.copy()
+	if err := gov.handler.importExclusionList(&list); err != nil {
+		t.Fatalf("importExclusionList returned error: %v", err)
+	}
+	if currentExclusionSet.hash != rm.activeExSet.hash {
+		t.Fatalf("active exclusion set changed for quarantined import")
+	}
+	qSets, err := rm.db.getExclusionSetsFromQuarantine()
+	if err != nil {
+		t.Fatalf("Failed to get exclusion sets from quarantine: %v", err)
+	}
+	if len(qSets) != 1 || qSets[0].hash != set.hash {
+		t.Fatalf("expected quarantined exclusion set %s, got %v", set.hash.Hex(), qSets)
+	}
+}
+
 func TestHandleConstitution(t *testing.T) {
 	rm := newTestRootManager(t, false, true)
 	bc := newTestChain(t, rm.RootManager)
@@ -892,6 +1075,64 @@ func randomExclusionList(t *testing.T, rm *TestRootManager, timestamp uint64, va
 		} else {
 			privateKeys = append(privateKeys, rm.rootPrivateKeys[:signersCount]...)
 		}
+	} else {
+		for i := 0; i < signersCount; i++ {
+			privateKey, err := crypto.GenerateKey()
+			if err != nil {
+				t.Error(errors.Wrap(err, "failed to generate random private key"))
+			}
+			privateKeys = append(privateKeys, privateKey)
+		}
+	}
+
+	for _, key := range privateKeys {
+		sig, err := crypto.Sign(exclusionList.Hash.Bytes(), key)
+		if err != nil {
+			t.Error(errors.Wrap(err, "failed to sign hash"))
+		}
+		exclusionList.Signatures = append(exclusionList.Signatures, sig)
+	}
+
+	return exclusionList
+}
+
+func signedExclusionList(t *testing.T, rm *TestRootManager, timestamp uint64, validatorsCount, signersCount int, signByAlias bool, blockStart uint64) common.ValidatorExclusionList {
+	exclusionList := common.ValidatorExclusionList{
+		Timestamp:  timestamp,
+		Validators: make([]common.ExcludedValidator, 0, validatorsCount),
+		Signatures: make([][]byte, 0, signersCount),
+	}
+	for i := 0; i < validatorsCount; i++ {
+		block := blockStart + uint64(i)
+		exclusionList.Validators = append(exclusionList.Validators, common.ExcludedValidator{
+			Address:  common.BytesToAddress(randBytes(common.AddressLength)),
+			Block:    block,
+			EndBlock: block + 100,
+		})
+	}
+
+	exclusionSet, err := newExclusionSet(&exclusionList)
+	if err != nil {
+		t.Error(err)
+	}
+	exclusionList.Hash = exclusionSet.hash
+
+	privateKeys := make([]*ecdsa.PrivateKey, 0)
+	if rm != nil && signersCount <= len(rm.rootPrivateKeys) {
+		if signByAlias {
+			privateKeys = append(privateKeys, rm.aliasPrivateKeys[:signersCount]...)
+		} else {
+			privateKeys = append(privateKeys, rm.rootPrivateKeys[:signersCount]...)
+		}
+	} else if rm != nil && signersCount <= len(rm.RootManager.manager.Accounts()) {
+		for _, account := range rm.RootManager.manager.Accounts()[:signersCount] {
+			signature, err := rm.SignHash(accounts.Account{Address: account}, exclusionList.Hash.Bytes())
+			if err != nil {
+				t.Error(errors.Wrap(err, "failed to sign hash"))
+			}
+			exclusionList.Signatures = append(exclusionList.Signatures, signature)
+		}
+		return exclusionList
 	} else {
 		for i := 0; i < signersCount; i++ {
 			privateKey, err := crypto.GenerateKey()

--- a/governance/handler_test.go
+++ b/governance/handler_test.go
@@ -383,6 +383,162 @@ func TestImportRootListDoesNotRequireLocalSigning(t *testing.T) {
 	}
 }
 
+func TestSubmitSignedRootList(t *testing.T) {
+	tests := []struct {
+		name              string
+		list              func(t *testing.T, rm *TestRootManager) common.RootList
+		beforeSubmit      func(t *testing.T, rm *TestRootManager, list common.RootList)
+		assertAfterSubmit func(t *testing.T, rm *TestRootManager, list common.RootList, hash common.Hash, err error)
+	}{
+		{
+			name: "known signer stores proposed list",
+			list: func(t *testing.T, rm *TestRootManager) common.RootList {
+				return randomRootList(t, rm, time.Now().Add(5*time.Minute).Unix(), 10, 1, true)
+			},
+			assertAfterSubmit: func(t *testing.T, rm *TestRootManager, list common.RootList, hash common.Hash, err error) {
+				if err != nil {
+					t.Fatalf("SubmitSignedRootList returned error: %v", err)
+				}
+				if hash != list.Hash {
+					t.Fatalf("expected hash %s, got %s", list.Hash.Hex(), hash.Hex())
+				}
+				if rm.proposed == nil || rm.proposed.hash != list.Hash {
+					t.Fatalf("expected proposed root list %s, got %v", list.Hash.Hex(), rm.proposed)
+				}
+			},
+		},
+		{
+			name: "threshold signatures upgrade active list",
+			list: func(t *testing.T, rm *TestRootManager) common.RootList {
+				return randomRootList(t, rm, time.Now().Add(5*time.Minute).Unix(), 10, defNumAccounts-1, true)
+			},
+			assertAfterSubmit: func(t *testing.T, rm *TestRootManager, list common.RootList, hash common.Hash, err error) {
+				if err != nil {
+					t.Fatalf("SubmitSignedRootList returned error: %v", err)
+				}
+				if hash != list.Hash {
+					t.Fatalf("expected hash %s, got %s", list.Hash.Hex(), hash.Hex())
+				}
+				if rm.active.hash != list.Hash {
+					t.Fatalf("expected active root list %s, got %s", list.Hash.Hex(), rm.active.hash.Hex())
+				}
+			},
+		},
+		{
+			name: "malformed hash is rejected",
+			list: func(t *testing.T, rm *TestRootManager) common.RootList {
+				list := randomRootList(t, rm, time.Now().Add(5*time.Minute).Unix(), 10, 1, true)
+				list.Hash = common.BytesToHash(randBytes(1))
+				return list
+			},
+			assertAfterSubmit: func(t *testing.T, rm *TestRootManager, list common.RootList, hash common.Hash, err error) {
+				if !errors.Is(err, errHashMismatch) {
+					t.Fatalf("expected hash mismatch, got hash %s err %v", hash.Hex(), err)
+				}
+				if rm.proposed != nil {
+					t.Fatalf("malformed root list changed proposed state: %v", rm.proposed)
+				}
+			},
+		},
+		{
+			name: "invalid signature is rejected",
+			list: func(t *testing.T, rm *TestRootManager) common.RootList {
+				list := randomRootList(t, rm, time.Now().Add(5*time.Minute).Unix(), 10, 1, true)
+				list.Signatures[0] = randBytes(crypto.SignatureLength)
+				return list
+			},
+			assertAfterSubmit: func(t *testing.T, rm *TestRootManager, list common.RootList, hash common.Hash, err error) {
+				if !errors.Is(err, errInvalidSignature) {
+					t.Fatalf("expected invalid signature, got hash %s err %v", hash.Hex(), err)
+				}
+				if rm.proposed != nil {
+					t.Fatalf("invalid signature changed proposed state: %v", rm.proposed)
+				}
+			},
+		},
+		{
+			name: "unknown signer is rejected",
+			list: func(t *testing.T, rm *TestRootManager) common.RootList {
+				return randomRootList(t, nil, time.Now().Add(5*time.Minute).Unix(), 10, 1, true)
+			},
+			assertAfterSubmit: func(t *testing.T, rm *TestRootManager, list common.RootList, hash common.Hash, err error) {
+				if err == nil {
+					t.Fatalf("expected unknown signer rejection, got hash %s", hash.Hex())
+				}
+				if rm.proposed != nil {
+					t.Fatalf("unknown signer changed proposed state: %v", rm.proposed)
+				}
+			},
+		},
+		{
+			name: "obsolete timestamp is rejected",
+			list: func(t *testing.T, rm *TestRootManager) common.RootList {
+				return randomRootList(t, rm, time.Now().Add(5*time.Minute).Unix(), 10, 1, true)
+			},
+			beforeSubmit: func(t *testing.T, rm *TestRootManager, list common.RootList) {
+				newer := randomRootList(t, rm, int64(list.Timestamp+1), 10, 1, true)
+				set, err := newRootSet(&newer)
+				if err != nil {
+					t.Fatal(err)
+				}
+				set.updateAliases(rm.getAliasesOfRoots(set.rootAddresses))
+				rm.proposed = set
+			},
+			assertAfterSubmit: func(t *testing.T, rm *TestRootManager, list common.RootList, hash common.Hash, err error) {
+				if err == nil {
+					t.Fatalf("expected obsolete root list rejection, got hash %s", hash.Hex())
+				}
+				if rm.proposed == nil || rm.proposed.hash == list.Hash {
+					t.Fatal("obsolete root list replaced newer proposal")
+				}
+			},
+		},
+		{
+			name: "duplicate is rejected",
+			list: func(t *testing.T, rm *TestRootManager) common.RootList {
+				return randomRootList(t, rm, time.Now().Add(5*time.Minute).Unix(), 10, 1, true)
+			},
+			beforeSubmit: func(t *testing.T, rm *TestRootManager, list common.RootList) {
+				set, err := newRootSet(&list)
+				if err != nil {
+					t.Fatal(err)
+				}
+				set.updateAliases(rm.getAliasesOfRoots(set.rootAddresses))
+				rm.proposed = set
+			},
+			assertAfterSubmit: func(t *testing.T, rm *TestRootManager, list common.RootList, hash common.Hash, err error) {
+				if err == nil {
+					t.Fatalf("expected duplicate root list rejection, got hash %s", hash.Hex())
+				}
+				if rm.proposed == nil || rm.proposed.hash != list.Hash || len(rm.proposed.signers) != 1 {
+					t.Fatalf("duplicate root list changed proposed state: %v", rm.proposed)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rm := newTestRootManager(t, false, true)
+			gov, err := New(rm.RootManager, tmpDirName(t))
+			if err != nil {
+				t.Fatalf("Failed to create Governance: %v", err)
+			}
+			if err := gov.Start(); err != nil {
+				t.Fatalf("Failed to start Governance: %v", err)
+			}
+			api := NewGovernancePublicAPI(gov)
+
+			list := tt.list(t, rm)
+			if tt.beforeSubmit != nil {
+				tt.beforeSubmit(t, rm, list)
+			}
+			hash, err := api.SubmitSignedRootList(list)
+			tt.assertAfterSubmit(t, rm, list, hash, err)
+		})
+	}
+}
+
 func TestHandleExclusionSet(t *testing.T) {
 	rm := newTestRootManager(t, false, true)
 	bc := newTestChain(t, rm.RootManager)

--- a/governance/handler_test.go
+++ b/governance/handler_test.go
@@ -391,6 +391,62 @@ func TestSubmitSignedRootList(t *testing.T) {
 		assertAfterSubmit func(t *testing.T, rm *TestRootManager, list common.RootList, hash common.Hash, err error)
 	}{
 		{
+			name: "disabled submissions are rejected",
+			list: func(t *testing.T, rm *TestRootManager) common.RootList {
+				return randomRootList(t, rm, time.Now().Add(5*time.Minute).Unix(), 10, 1, true)
+			},
+			beforeSubmit: func(t *testing.T, rm *TestRootManager, list common.RootList) {
+				rm.DisablePublicSubmission = true
+			},
+			assertAfterSubmit: func(t *testing.T, rm *TestRootManager, list common.RootList, hash common.Hash, err error) {
+				if !errors.Is(err, errPublicGovernanceSubmissionDisabled) {
+					t.Fatalf("expected disabled submission error, got hash %s err %v", hash.Hex(), err)
+				}
+				if rm.proposed != nil {
+					t.Fatalf("disabled submission changed proposed state: %v", rm.proposed)
+				}
+			},
+		},
+		{
+			name: "oversized payload is rejected",
+			list: func(t *testing.T, rm *TestRootManager) common.RootList {
+				return randomRootList(t, nil, time.Now().Add(5*time.Minute).Unix(), 2*maxNRootNodes+1, 2*maxNRootNodes+1, true)
+			},
+			assertAfterSubmit: func(t *testing.T, rm *TestRootManager, list common.RootList, hash common.Hash, err error) {
+				if !errors.Is(err, errMsgTooLarge) {
+					t.Fatalf("expected oversized root list error, got hash %s err %v", hash.Hex(), err)
+				}
+				if rm.proposed != nil {
+					t.Fatalf("oversized root list changed proposed state: %v", rm.proposed)
+				}
+			},
+		},
+		{
+			name: "quota exceeded is rejected",
+			list: func(t *testing.T, rm *TestRootManager) common.RootList {
+				return randomRootList(t, rm, time.Now().Add(5*time.Minute).Unix(), 10, 1, true)
+			},
+			beforeSubmit: func(t *testing.T, rm *TestRootManager, list common.RootList) {
+				rm.ProposalQuotaMax = 1
+				rm.ProposalQuotaTimeWindow = time.Hour
+				set, err := newRootSet(&list)
+				if err != nil {
+					t.Fatal(err)
+				}
+				rm.rootQuotaEntries[rm.active.knownSigners(set.signers)[0]] = []common.ListQuotaEntry{
+					{Hash: common.BytesToHash(randBytes(common.HashLength)), Timestamp: uint64(time.Now().Unix())},
+				}
+			},
+			assertAfterSubmit: func(t *testing.T, rm *TestRootManager, list common.RootList, hash common.Hash, err error) {
+				if err == nil {
+					t.Fatalf("expected quota error, got hash %s", hash.Hex())
+				}
+				if rm.proposed != nil {
+					t.Fatalf("quota rejected root list changed proposed state: %v", rm.proposed)
+				}
+			},
+		},
+		{
 			name: "known signer stores proposed list",
 			list: func(t *testing.T, rm *TestRootManager) common.RootList {
 				return randomRootList(t, rm, time.Now().Add(5*time.Minute).Unix(), 10, 1, true)
@@ -834,15 +890,74 @@ func TestSubmitSignedExclusionList(t *testing.T) {
 		initChain         bool
 		list              func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList
 		beforeSubmit      func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList)
-		assertAfterSubmit func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList, hash common.Hash)
+		assertAfterSubmit func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList, hash common.Hash, err error)
 		wantErr           bool
 	}{
+		{
+			name: "disabled submissions are rejected",
+			list: func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList {
+				return signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, 1, true, 6000)
+			},
+			beforeSubmit: func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList) {
+				rm.DisablePublicSubmission = true
+			},
+			assertAfterSubmit: func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList, hash common.Hash, err error) {
+				if !errors.Is(err, errPublicGovernanceSubmissionDisabled) {
+					t.Fatalf("expected disabled submission error, got hash %s err %v", hash.Hex(), err)
+				}
+				if rm.proposedExSet != nil {
+					t.Fatalf("disabled submission changed proposed state: %v", rm.proposedExSet)
+				}
+			},
+		},
+		{
+			name: "oversized payload is rejected",
+			list: func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList {
+				return randomExclusionList(t, nil, uint64(time.Now().Add(5*time.Minute).Unix()), 2*maxNRootNodes+1, 2*maxNRootNodes+1, true)
+			},
+			assertAfterSubmit: func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList, hash common.Hash, err error) {
+				if !errors.Is(err, errMsgTooLarge) {
+					t.Fatalf("expected oversized exclusion list error, got hash %s err %v", hash.Hex(), err)
+				}
+				if rm.proposedExSet != nil {
+					t.Fatalf("oversized exclusion list changed proposed state: %v", rm.proposedExSet)
+				}
+			},
+		},
+		{
+			name: "quota exceeded is rejected",
+			list: func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList {
+				return signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, 1, true, 6000)
+			},
+			beforeSubmit: func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList) {
+				rm.ProposalQuotaMax = 1
+				rm.ProposalQuotaTimeWindow = time.Hour
+				set, err := newExclusionSet(&list)
+				if err != nil {
+					t.Fatal(err)
+				}
+				rm.exclusionQuotaEntries[rm.getActiveRootSet(true).knownSigners(set.signers)[0]] = []common.ListQuotaEntry{
+					{Hash: common.BytesToHash(randBytes(common.HashLength)), Timestamp: uint64(time.Now().Unix())},
+				}
+			},
+			assertAfterSubmit: func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList, hash common.Hash, err error) {
+				if err == nil {
+					t.Fatalf("expected quota error, got hash %s", hash.Hex())
+				}
+				if rm.proposedExSet != nil {
+					t.Fatalf("quota rejected exclusion list changed proposed state: %v", rm.proposedExSet)
+				}
+			},
+		},
 		{
 			name: "known signer stores proposed list",
 			list: func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList {
 				return signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, 1, true, 6000)
 			},
-			assertAfterSubmit: func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList, hash common.Hash) {
+			assertAfterSubmit: func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList, hash common.Hash, err error) {
+				if err != nil {
+					t.Fatalf("SubmitSignedExclusionList returned error: %v", err)
+				}
 				if hash != list.Hash {
 					t.Fatalf("expected submitted hash %s, got %s", list.Hash.Hex(), hash.Hex())
 				}
@@ -857,7 +972,10 @@ func TestSubmitSignedExclusionList(t *testing.T) {
 				return signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, defNumAccounts-1, true, 6000)
 			},
 			initChain: true,
-			assertAfterSubmit: func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList, hash common.Hash) {
+			assertAfterSubmit: func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList, hash common.Hash, err error) {
+				if err != nil {
+					t.Fatalf("SubmitSignedExclusionList returned error: %v", err)
+				}
 				if rm.activeExSet == nil || rm.activeExSet.hash != list.Hash {
 					t.Fatalf("expected active exclusion list %s, got %v", list.Hash.Hex(), rm.activeExSet)
 				}
@@ -980,6 +1098,10 @@ func TestSubmitSignedExclusionList(t *testing.T) {
 				tt.beforeSubmit(t, rm, list)
 			}
 			hash, err := api.SubmitSignedExclusionList(list)
+			if tt.assertAfterSubmit != nil {
+				tt.assertAfterSubmit(t, rm, list, hash, err)
+				return
+			}
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected SubmitSignedExclusionList error")
@@ -989,7 +1111,7 @@ func TestSubmitSignedExclusionList(t *testing.T) {
 			if err != nil {
 				t.Fatalf("SubmitSignedExclusionList returned error: %v", err)
 			}
-			tt.assertAfterSubmit(t, rm, list, hash)
+			tt.assertAfterSubmit(t, rm, list, hash, err)
 		})
 	}
 }

--- a/governance/handler_test.go
+++ b/governance/handler_test.go
@@ -595,6 +595,302 @@ func TestSubmitSignedRootList(t *testing.T) {
 	}
 }
 
+func TestSubmitSignedRootListEquivalentToPeerImport(t *testing.T) {
+	tests := []struct {
+		name           string
+		list           func(t *testing.T, rm *TestRootManager) common.RootList
+		beforeImport   func(t *testing.T, rm *TestRootManager, list common.RootList)
+		wantRPCError   bool
+		compareStates  bool
+		compareNoState bool
+	}{
+		{
+			name: "valid proposal",
+			list: func(t *testing.T, rm *TestRootManager) common.RootList {
+				return randomRootList(t, rm, time.Now().Add(5*time.Minute).Unix(), 10, 1, true)
+			},
+			compareStates: true,
+		},
+		{
+			name: "threshold upgrade",
+			list: func(t *testing.T, rm *TestRootManager) common.RootList {
+				return randomRootList(t, rm, time.Now().Add(5*time.Minute).Unix(), 10, defNumAccounts-1, true)
+			},
+			compareStates: true,
+		},
+		{
+			name: "duplicate proposal",
+			list: func(t *testing.T, rm *TestRootManager) common.RootList {
+				return randomRootList(t, rm, time.Now().Add(5*time.Minute).Unix(), 10, 1, true)
+			},
+			beforeImport: func(t *testing.T, rm *TestRootManager, list common.RootList) {
+				set, err := newRootSet(&list)
+				if err != nil {
+					t.Fatal(err)
+				}
+				set.updateAliases(rm.getAliasesOfRoots(set.rootAddresses))
+				rm.proposed = set
+			},
+			wantRPCError:   true,
+			compareNoState: true,
+		},
+		{
+			name: "stale proposal",
+			list: func(t *testing.T, rm *TestRootManager) common.RootList {
+				return randomRootList(t, rm, time.Now().Add(5*time.Minute).Unix(), 10, 1, true)
+			},
+			beforeImport: func(t *testing.T, rm *TestRootManager, list common.RootList) {
+				newer := randomRootList(t, rm, int64(list.Timestamp+1), 10, 1, true)
+				set, err := newRootSet(&newer)
+				if err != nil {
+					t.Fatal(err)
+				}
+				set.updateAliases(rm.getAliasesOfRoots(set.rootAddresses))
+				rm.proposed = set
+			},
+			wantRPCError:   true,
+			compareNoState: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			peerRM := newTestRootManager(t, false, true)
+			rpcRM := newTestRootManager(t, false, true)
+
+			list := tt.list(t, peerRM)
+			cloneRootManagerRootState(rpcRM.RootManager, peerRM.RootManager)
+			if tt.beforeImport != nil {
+				tt.beforeImport(t, peerRM, list)
+				tt.beforeImport(t, rpcRM, list)
+			}
+
+			peerGov, err := New(peerRM.RootManager, tmpDirName(t))
+			if err != nil {
+				t.Fatalf("Failed to create peer Governance: %v", err)
+			}
+			rpcGov, err := New(rpcRM.RootManager, tmpDirName(t))
+			if err != nil {
+				t.Fatalf("Failed to create rpc Governance: %v", err)
+			}
+			if err := peerGov.Start(); err != nil {
+				t.Fatalf("Failed to start peer Governance: %v", err)
+			}
+			if err := rpcGov.Start(); err != nil {
+				t.Fatalf("Failed to start rpc Governance: %v", err)
+			}
+
+			peerBefore := peerRM.rootListImportSnapshot(list.Hash)
+			rpcBefore := rpcRM.rootListImportSnapshot(list.Hash)
+			if err := peerGov.handler.importRootListFrom("peer", &list, false); err != nil {
+				t.Fatalf("peer import failed: %v", err)
+			}
+			_, rpcErr := NewGovernancePublicAPI(rpcGov).SubmitSignedRootList(list)
+			if tt.wantRPCError && rpcErr == nil {
+				t.Fatal("expected RPC import error")
+			}
+			if !tt.wantRPCError && rpcErr != nil {
+				t.Fatalf("RPC import failed: %v", rpcErr)
+			}
+
+			if tt.compareStates {
+				assertRootImportStateEqual(t, peerRM.RootManager, rpcRM.RootManager, list.Hash)
+			}
+			if tt.compareNoState {
+				if peerRM.rootListImportSnapshot(list.Hash).changedFrom(peerBefore) {
+					t.Fatal("peer path mutated state for ignored root list")
+				}
+				if rpcRM.rootListImportSnapshot(list.Hash).changedFrom(rpcBefore) {
+					t.Fatal("RPC path mutated state for ignored root list")
+				}
+			}
+		})
+	}
+}
+
+func cloneRootManagerRootState(dst, src *RootManager) {
+	dst.active = src.active.copy()
+	dst.desired = src.desired.copy()
+	dst.proposed = src.proposed.copy()
+	dst.reg = newTestRegistry()
+	dst.rootQuotaEntries = map[common.Address][]common.ListQuotaEntry{}
+	for signer, entries := range src.rootQuotaEntries {
+		dst.rootQuotaEntries[signer] = append([]common.ListQuotaEntry(nil), entries...)
+	}
+}
+
+func assertRootImportStateEqual(t *testing.T, peerRM, rpcRM *RootManager, hash common.Hash) {
+	t.Helper()
+	if peerRM.rootListImportSnapshot(hash) != rpcRM.rootListImportSnapshot(hash) {
+		t.Fatalf("root import state mismatch: peer=%+v rpc=%+v", peerRM.rootListImportSnapshot(hash), rpcRM.rootListImportSnapshot(hash))
+	}
+}
+
+func assertExclusionImportStateEqual(t *testing.T, peerRM, rpcRM *RootManager, hash common.Hash) {
+	t.Helper()
+	if peerRM.exclusionListImportSnapshot(hash) != rpcRM.exclusionListImportSnapshot(hash) {
+		t.Fatalf("exclusion import state mismatch: peer=%+v rpc=%+v", peerRM.exclusionListImportSnapshot(hash), rpcRM.exclusionListImportSnapshot(hash))
+	}
+}
+
+func TestSubmitSignedExclusionListEquivalentToPeerImport(t *testing.T) {
+	tests := []struct {
+		name           string
+		initChain      bool
+		list           func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList
+		beforeImport   func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList)
+		wantRPCError   bool
+		compareStates  bool
+		compareNoState bool
+		compareQuarant bool
+	}{
+		{
+			name: "valid proposal",
+			list: func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList {
+				return signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, 1, true, 6000)
+			},
+			compareStates: true,
+		},
+		{
+			name:      "threshold upgrade",
+			initChain: true,
+			list: func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList {
+				return signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, defNumAccounts-1, true, 6000)
+			},
+			compareStates: true,
+		},
+		{
+			name: "duplicate proposal",
+			list: func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList {
+				return signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, 1, true, 6000)
+			},
+			beforeImport: func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList) {
+				set, err := newExclusionSet(&list)
+				if err != nil {
+					t.Fatal(err)
+				}
+				rm.proposedExSet = set
+			},
+			wantRPCError:   true,
+			compareNoState: true,
+		},
+		{
+			name: "stale proposal",
+			list: func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList {
+				return signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, 1, true, 6000)
+			},
+			beforeImport: func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList) {
+				newer := signedExclusionList(t, rm, list.Timestamp+1, 2, 1, true, 7000)
+				set, err := newExclusionSet(&newer)
+				if err != nil {
+					t.Fatal(err)
+				}
+				rm.proposedExSet = set
+			},
+			wantRPCError:   true,
+			compareNoState: true,
+		},
+		{
+			name:      "quarantine",
+			initChain: true,
+			list: func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList {
+				rm.setMaxRewindLimit(100)
+				list := rm.activeExSet.copy().makeList()
+				list.Timestamp++
+				list.Signatures = nil
+				list.Hash = common.Hash{}
+				list.Validators = append(list.Validators, common.ExcludedValidator{
+					Address: common.HexToAddress("0x2B01035cDa82a02fb135EBd68676Fa17FdcAD365"),
+					Block:   2,
+				})
+				set, err := newExclusionSet(&list)
+				if err != nil {
+					t.Fatal(err)
+				}
+				rm.signExclusionSet(set)
+				return set.makeList()
+			},
+			wantRPCError:   true,
+			compareQuarant: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			peerRM := newTestRootManager(t, false, true)
+			rpcRM := newTestRootManager(t, false, true)
+			if tt.initChain {
+				peerRM = newTestRootManager(t, true, false)
+				rpcRM = newTestRootManager(t, true, false)
+				peerBC := newTestChain(t, peerRM.RootManager)
+				defer peerBC.Stop()
+				rpcBC := newTestChain(t, rpcRM.RootManager)
+				defer rpcBC.Stop()
+				peerRM.InitBlockChain(peerBC)
+				rpcRM.InitBlockChain(rpcBC)
+			}
+
+			list := tt.list(t, peerRM)
+			cloneRootManagerRootState(rpcRM.RootManager, peerRM.RootManager)
+			rpcRM.activeExSet = peerRM.activeExSet.copy()
+			rpcRM.desiredExSet = peerRM.desiredExSet.copy()
+			rpcRM.proposedExSet = peerRM.proposedExSet.copy()
+			rpcRM.rewindLimit = peerRM.rewindLimit
+			if tt.beforeImport != nil {
+				tt.beforeImport(t, peerRM, list)
+				tt.beforeImport(t, rpcRM, list)
+			}
+
+			peerGov, err := New(peerRM.RootManager, tmpDirName(t))
+			if err != nil {
+				t.Fatalf("Failed to create peer Governance: %v", err)
+			}
+			rpcGov, err := New(rpcRM.RootManager, tmpDirName(t))
+			if err != nil {
+				t.Fatalf("Failed to create rpc Governance: %v", err)
+			}
+			if err := peerGov.Start(); err != nil {
+				t.Fatalf("Failed to start peer Governance: %v", err)
+			}
+			if err := rpcGov.Start(); err != nil {
+				t.Fatalf("Failed to start rpc Governance: %v", err)
+			}
+
+			peerBefore := peerRM.exclusionListImportSnapshot(list.Hash)
+			rpcBefore := rpcRM.exclusionListImportSnapshot(list.Hash)
+			if err := peerGov.handler.importExclusionListFrom("peer", &list, false); err != nil {
+				t.Fatalf("peer import failed: %v", err)
+			}
+			_, rpcErr := NewGovernancePublicAPI(rpcGov).SubmitSignedExclusionList(list)
+			if tt.wantRPCError && rpcErr == nil {
+				t.Fatal("expected RPC import error")
+			}
+			if !tt.wantRPCError && rpcErr != nil {
+				t.Fatalf("RPC import failed: %v", rpcErr)
+			}
+
+			if tt.compareStates {
+				assertExclusionImportStateEqual(t, peerRM.RootManager, rpcRM.RootManager, list.Hash)
+			}
+			if tt.compareNoState {
+				if peerRM.exclusionListImportSnapshot(list.Hash).changedFrom(peerBefore) {
+					t.Fatal("peer path mutated state for ignored exclusion list")
+				}
+				if rpcRM.exclusionListImportSnapshot(list.Hash).changedFrom(rpcBefore) {
+					t.Fatal("RPC path mutated state for ignored exclusion list")
+				}
+			}
+			if tt.compareQuarant {
+				peerChanged := peerRM.exclusionListImportSnapshot(list.Hash).changedFrom(peerBefore)
+				rpcChanged := rpcRM.exclusionListImportSnapshot(list.Hash).changedFrom(rpcBefore)
+				if !peerChanged || rpcChanged {
+					t.Fatalf("expected peer quarantine mutation and RPC rejection, peerChanged=%v rpcChanged=%v", peerChanged, rpcChanged)
+				}
+			}
+		})
+	}
+}
+
 func TestHandleExclusionSet(t *testing.T) {
 	rm := newTestRootManager(t, false, true)
 	bc := newTestChain(t, rm.RootManager)

--- a/governance/handler_test.go
+++ b/governance/handler_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"gitlab.com/q-dev/q-client/accounts"
 	"gitlab.com/q-dev/q-client/common"
 	"gitlab.com/q-dev/q-client/crypto"
 	"gitlab.com/q-dev/q-client/log"
@@ -231,6 +232,154 @@ func TestHandleRootSet(t *testing.T) {
 			}
 		})
 		rm.active = startRootList
+	}
+}
+
+func TestImportRootList(t *testing.T) {
+	tests := []struct {
+		name              string
+		list              func(t *testing.T, rm *TestRootManager) common.RootList
+		beforeImport      func(t *testing.T, rm *TestRootManager, list common.RootList)
+		assertAfterImport func(t *testing.T, rm *TestRootManager, list common.RootList)
+	}{
+		{
+			name: "known signer stores proposed list",
+			list: func(t *testing.T, rm *TestRootManager) common.RootList {
+				return randomRootList(t, rm, time.Now().Add(5*time.Minute).Unix(), 10, 1, true)
+			},
+			assertAfterImport: func(t *testing.T, rm *TestRootManager, list common.RootList) {
+				if rm.proposed == nil || rm.proposed.hash != list.Hash {
+					t.Fatalf("expected proposed root list %s, got %v", list.Hash.Hex(), rm.proposed)
+				}
+				if rm.active.hash == list.Hash {
+					t.Fatal("single-signature root list was upgraded")
+				}
+			},
+		},
+		{
+			name: "unknown signer is ignored",
+			list: func(t *testing.T, rm *TestRootManager) common.RootList {
+				return randomRootList(t, nil, time.Now().Add(5*time.Minute).Unix(), 10, 1, true)
+			},
+			assertAfterImport: func(t *testing.T, rm *TestRootManager, list common.RootList) {
+				if rm.proposed != nil {
+					t.Fatalf("expected unknown signer root list to be ignored, got %s", rm.proposed.hash.Hex())
+				}
+			},
+		},
+		{
+			name: "duplicate signature is ignored",
+			list: func(t *testing.T, rm *TestRootManager) common.RootList {
+				list := randomRootList(t, rm, time.Now().Add(5*time.Minute).Unix(), 10, 1, true)
+				list.Signatures = append(list.Signatures, list.Signatures[0])
+				return list
+			},
+			assertAfterImport: func(t *testing.T, rm *TestRootManager, list common.RootList) {
+				if rm.proposed == nil || rm.proposed.hash != list.Hash {
+					t.Fatalf("expected proposed root list %s, got %v", list.Hash.Hex(), rm.proposed)
+				}
+				if len(rm.proposed.signers) != 1 {
+					t.Fatalf("expected one unique signature, got %d", len(rm.proposed.signers))
+				}
+			},
+		},
+		{
+			name: "obsolete timestamp is ignored",
+			list: func(t *testing.T, rm *TestRootManager) common.RootList {
+				return randomRootList(t, rm, time.Now().Add(5*time.Minute).Unix(), 10, 1, true)
+			},
+			beforeImport: func(t *testing.T, rm *TestRootManager, list common.RootList) {
+				newer := randomRootList(t, rm, int64(list.Timestamp+1), 10, 1, true)
+				set, err := newRootSet(&newer)
+				if err != nil {
+					t.Fatal(err)
+				}
+				set.updateAliases(rm.getAliasesOfRoots(set.rootAddresses))
+				rm.proposed = set
+			},
+			assertAfterImport: func(t *testing.T, rm *TestRootManager, list common.RootList) {
+				if rm.proposed == nil || rm.proposed.hash == list.Hash {
+					t.Fatal("obsolete root list replaced newer proposal")
+				}
+			},
+		},
+		{
+			name: "threshold signatures upgrade active list",
+			list: func(t *testing.T, rm *TestRootManager) common.RootList {
+				return randomRootList(t, rm, time.Now().Add(5*time.Minute).Unix(), 10, defNumAccounts-1, true)
+			},
+			assertAfterImport: func(t *testing.T, rm *TestRootManager, list common.RootList) {
+				if rm.active.hash != list.Hash {
+					t.Fatalf("expected active root list %s, got %s", list.Hash.Hex(), rm.active.hash.Hex())
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rm := newTestRootManager(t, false, true)
+			gov, err := New(rm.RootManager, tmpDirName(t))
+			if err != nil {
+				t.Fatalf("Failed to create Governance: %v", err)
+			}
+			if err := gov.Start(); err != nil {
+				t.Fatalf("Failed to start Governance: %v", err)
+			}
+
+			list := tt.list(t, rm)
+			if tt.beforeImport != nil {
+				tt.beforeImport(t, rm, list)
+			}
+			if err := gov.handler.importRootList(&list); err != nil {
+				t.Fatalf("importRootList returned error: %v", err)
+			}
+			tt.assertAfterImport(t, rm, list)
+		})
+	}
+}
+
+func TestImportRootListDoesNotRequireLocalSigning(t *testing.T) {
+	rm := newTestRootManager(t, true, false)
+	gov, err := New(rm.RootManager, tmpDirName(t))
+	if err != nil {
+		t.Fatalf("Failed to create Governance: %v", err)
+	}
+	if err := gov.Start(); err != nil {
+		t.Fatalf("Failed to start Governance: %v", err)
+	}
+
+	list := common.RootList{
+		Timestamp: uint64(time.Now().Add(5 * time.Minute).Unix()),
+		Nodes: []common.Address{
+			common.BytesToAddress(randBytes(common.AddressLength)),
+			common.BytesToAddress(randBytes(common.AddressLength)),
+			common.BytesToAddress(randBytes(common.AddressLength)),
+		},
+	}
+	set, err := newRootSet(&list)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signature, err := rm.SignHash(accounts.Account{Address: rm.active.rootAddresses[0]}, set.hash.Bytes())
+	if err != nil {
+		t.Fatalf("failed to sign root list: %v", err)
+	}
+	list.Hash = set.hash
+	list.Signatures = [][]byte{signature}
+
+	if err := gov.handler.importRootList(&list); err != nil {
+		t.Fatalf("importRootList returned error: %v", err)
+	}
+
+	if rm.active.hash == list.Hash {
+		t.Fatal("import locally signed the root list and upgraded it")
+	}
+	if rm.proposed == nil || rm.proposed.hash != list.Hash {
+		t.Fatalf("expected imported root list to be proposed, got %v", rm.proposed)
+	}
+	if len(rm.proposed.signers) != 1 {
+		t.Fatalf("expected import to keep only supplied signature, got %d signatures", len(rm.proposed.signers))
 	}
 }
 

--- a/governance/handler_test.go
+++ b/governance/handler_test.go
@@ -828,6 +828,172 @@ func TestImportExclusionListPreservesQuarantine(t *testing.T) {
 	}
 }
 
+func TestSubmitSignedExclusionList(t *testing.T) {
+	tests := []struct {
+		name              string
+		initChain         bool
+		list              func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList
+		beforeSubmit      func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList)
+		assertAfterSubmit func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList, hash common.Hash)
+		wantErr           bool
+	}{
+		{
+			name: "known signer stores proposed list",
+			list: func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList {
+				return signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, 1, true, 6000)
+			},
+			assertAfterSubmit: func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList, hash common.Hash) {
+				if hash != list.Hash {
+					t.Fatalf("expected submitted hash %s, got %s", list.Hash.Hex(), hash.Hex())
+				}
+				if rm.proposedExSet == nil || rm.proposedExSet.hash != list.Hash {
+					t.Fatalf("expected proposed exclusion list %s, got %v", list.Hash.Hex(), rm.proposedExSet)
+				}
+			},
+		},
+		{
+			name: "threshold signatures upgrade active list",
+			list: func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList {
+				return signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, defNumAccounts-1, true, 6000)
+			},
+			initChain: true,
+			assertAfterSubmit: func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList, hash common.Hash) {
+				if rm.activeExSet == nil || rm.activeExSet.hash != list.Hash {
+					t.Fatalf("expected active exclusion list %s, got %v", list.Hash.Hex(), rm.activeExSet)
+				}
+			},
+		},
+		{
+			name: "unknown signer is rejected",
+			list: func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList {
+				return signedExclusionList(t, nil, uint64(time.Now().Add(5*time.Minute).Unix()), 2, 1, true, 6000)
+			},
+			wantErr: true,
+		},
+		{
+			name: "unsigned list is rejected",
+			list: func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList {
+				list := signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, 1, true, 6000)
+				list.Signatures = nil
+				return list
+			},
+			wantErr: true,
+		},
+		{
+			name: "malformed signature is rejected",
+			list: func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList {
+				list := signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, 1, true, 6000)
+				list.Signatures[0] = randBytes(crypto.SignatureLength)
+				return list
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid range is rejected",
+			list: func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList {
+				list := signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, 1, true, 6000)
+				list.Validators[0].EndBlock = list.Validators[0].Block
+				list.Hash = common.Hash{}
+				list.Signatures = nil
+				set, err := newExclusionSet(&list)
+				if err != nil {
+					t.Fatal(err)
+				}
+				rm.signExclusionSet(set)
+				return set.makeList()
+			},
+			wantErr: true,
+		},
+		{
+			name: "obsolete timestamp is rejected",
+			list: func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList {
+				return signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, 1, true, 6000)
+			},
+			beforeSubmit: func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList) {
+				newer := signedExclusionList(t, rm, list.Timestamp+1, 2, 1, true, 7000)
+				set, err := newExclusionSet(&newer)
+				if err != nil {
+					t.Fatal(err)
+				}
+				rm.proposedExSet = set
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplicate is rejected",
+			list: func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList {
+				return signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, 1, true, 6000)
+			},
+			beforeSubmit: func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList) {
+				set, err := newExclusionSet(&list)
+				if err != nil {
+					t.Fatal(err)
+				}
+				rm.proposedExSet = set
+			},
+			wantErr: true,
+		},
+		{
+			name:      "quarantined list is rejected",
+			initChain: true,
+			list: func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList {
+				rm.setMaxRewindLimit(100)
+				list := rm.activeExSet.copy().makeList()
+				list.Timestamp++
+				list.Signatures = nil
+				list.Hash = common.Hash{}
+				list.Validators = append(list.Validators, common.ExcludedValidator{
+					Address: common.HexToAddress("0x2B01035cDa82a02fb135EBd68676Fa17FdcAD365"),
+					Block:   2,
+				})
+				set, err := newExclusionSet(&list)
+				if err != nil {
+					t.Fatal(err)
+				}
+				rm.signExclusionSet(set)
+				return set.makeList()
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rm := newTestRootManager(t, false, true)
+			if tt.initChain {
+				rm = newTestRootManager(t, true, false)
+				bc := newTestChain(t, rm.RootManager)
+				defer bc.Stop()
+				rm.InitBlockChain(bc)
+			}
+			gov, err := New(rm.RootManager, tmpDirName(t))
+			if err != nil {
+				t.Fatalf("Failed to create Governance: %v", err)
+			}
+			if err := gov.Start(); err != nil {
+				t.Fatalf("Failed to start Governance: %v", err)
+			}
+
+			api := NewGovernancePublicAPI(gov)
+			list := tt.list(t, rm)
+			if tt.beforeSubmit != nil {
+				tt.beforeSubmit(t, rm, list)
+			}
+			hash, err := api.SubmitSignedExclusionList(list)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected SubmitSignedExclusionList error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("SubmitSignedExclusionList returned error: %v", err)
+			}
+			tt.assertAfterSubmit(t, rm, list, hash)
+		})
+	}
+}
+
 func TestHandleConstitution(t *testing.T) {
 	rm := newTestRootManager(t, false, true)
 	bc := newTestChain(t, rm.RootManager)

--- a/governance/root_manager.go
+++ b/governance/root_manager.go
@@ -44,6 +44,9 @@ var (
 	errProposedApprovalListEmpty  = errors.New("proposed approval list is empty")
 	errInvalidApprovalBlockNumber = errors.New("proposed approval list contains wrong block number")
 	errExclusionListQuotaExceeded = errors.New("exclusion list quota exceeded")
+
+	errPublicGovernanceSubmissionDisabled = errors.New("public governance submission is disabled")
+	errGovernanceSubmissionTooLarge       = errors.New("governance submission is too large")
 )
 
 // RootManager stores root and exclusion lists.
@@ -86,6 +89,7 @@ type RootManager struct {
 	exclusionQuotaEntries map[common.Address][]common.ListQuotaEntry
 
 	ProposalQuotaMax        uint
+	DisablePublicSubmission bool
 	rootQuotaLock           sync.Mutex
 	ProposalQuotaTimeWindow time.Duration
 	exclusionQuotaLock      sync.Mutex
@@ -103,6 +107,7 @@ type Config struct {
 	ProposalQuotaTimeWindow       time.Duration
 	ApprovalMaxFailures           uint64
 	TransitionBlockVerifiedBlocks uint64
+	DisablePublicSubmission       bool
 }
 
 type DiffEntry struct {
@@ -174,6 +179,7 @@ func NewRootManager(am *accounts.Manager, networkId uint64, datadir string, cfg 
 		exclusionQuotaEntries: exclusionQuotaEntries,
 
 		ProposalQuotaMax:        cfg.ProposalQuotaMax,
+		DisablePublicSubmission: cfg.DisablePublicSubmission,
 		ProposalQuotaTimeWindow: cfg.ProposalQuotaTimeWindow,
 
 		ApprovalMaxFailures: cfg.ApprovalMaxFailures,
@@ -1363,6 +1369,14 @@ func (s *RootManager) acceptQuarantinedExclusionSet(hash *common.Hash) error {
 }
 
 func (s *RootManager) isSetQuotaExceeded(received interface{}) (bool, error) {
+	return s.checkSetQuotaExceeded(received, true)
+}
+
+func (s *RootManager) isSetQuotaExceededDryRun(received interface{}) (bool, error) {
+	return s.checkSetQuotaExceeded(received, false)
+}
+
+func (s *RootManager) checkSetQuotaExceeded(received interface{}, mutate bool) (bool, error) {
 	var (
 		prefix         []byte
 		hash           common.Hash
@@ -1406,8 +1420,8 @@ func (s *RootManager) isSetQuotaExceeded(received interface{}) (bool, error) {
 		}
 	}
 
-	// Need to save cleaned quotas anyway.
-	if !reflect.DeepEqual(currentEntries, resEntries) {
+	// Need to save cleaned quotas anyway when this is the mutating import path.
+	if mutate && !reflect.DeepEqual(currentEntries, resEntries) {
 		if err := s.saveQuotas(received, resEntries, prefix); err != nil {
 			return false, errors.Wrap(err, "failed to save quota entries")
 		}
@@ -1425,7 +1439,7 @@ func (s *RootManager) isSetQuotaExceeded(received interface{}) (bool, error) {
 
 	// Check if there's already an entry for this signer or if the quota is exceeded
 	if entries, ok := resEntries[signer]; ok {
-		if len(entries) >= int(s.ProposalQuotaMax) {
+		if s.ProposalQuotaMax > 0 && len(entries) >= int(s.ProposalQuotaMax) {
 			// Quota exceeded
 			return true, nil
 		}
@@ -1435,6 +1449,14 @@ func (s *RootManager) isSetQuotaExceeded(received interface{}) (bool, error) {
 				return false, nil
 			}
 		}
+	}
+
+	if s.ProposalQuotaMax > 0 && len(resEntries[signer]) >= int(s.ProposalQuotaMax) {
+		return true, nil
+	}
+
+	if !mutate {
+		return false, nil
 	}
 
 	// We are here, this means that no entry found and quota is not exceeded. Add new entry

--- a/governance/root_manager_test.go
+++ b/governance/root_manager_test.go
@@ -870,7 +870,7 @@ func TestQuarantineExclusionSet(t *testing.T) {
 
 	t.Log("Handling exclusion set")
 	currentExclusionSet := rm.activeExSet.copy()
-	err = gov.handler.handleExclusionSet(&p, set)
+	err = gov.handler.importExclusionSet(p.id, set, true)
 	if err != nil {
 		t.Fatalf("Failed to handle exclusion list: %v", err)
 	}

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -961,6 +961,11 @@ web3._extend({
 			call: 'govPub_onchainRootList',
 			params: 0
 		}),
+		new web3._extend.Method({
+			name: 'submitSignedRootList',
+			call: 'govPub_submitSignedRootList',
+			params: 1
+		}),
 	    new web3._extend.Method({
 			name: 'diffRootList',
 			call: 'govPub_diffRootList',
@@ -980,6 +985,11 @@ web3._extend({
 			name: 'proposedExclusionList',
 			call: 'govPub_proposedExclusionList',
 			params: 0
+		}),
+		new web3._extend.Method({
+			name: 'submitSignedExclusionList',
+			call: 'govPub_submitSignedExclusionList',
+			params: 1
 		}),
 	    new web3._extend.Method({
 			name: 'diffExclusionList',

--- a/internal/web3ext/web3ext_test.go
+++ b/internal/web3ext/web3ext_test.go
@@ -1,0 +1,19 @@
+package web3ext
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestGovernanceSubmissionWeb3Extensions(t *testing.T) {
+	for _, expected := range []string{
+		"name: 'submitSignedRootList'",
+		"call: 'govPub_submitSignedRootList'",
+		"name: 'submitSignedExclusionList'",
+		"call: 'govPub_submitSignedExclusionList'",
+	} {
+		if !bytes.Contains([]byte(GovPublicJs), []byte(expected)) {
+			t.Fatalf("GovPublicJs missing %q", expected)
+		}
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Routes peer-originated root-list and exclusion-list messages through reusable import paths.
- Adds public `govPub_submitSignedRootList` and `govPub_submitSignedExclusionList` endpoints for externally signed submissions.
- Exposes submission helpers in web3ext and ethclient.
- Keeps private `gov` blocked while allowing `govPub` on external RPC transports.
- Adds public submission controls for disabled mode, size limits, quota checks, malformed payloads, and quarantine rejection.
- Adds RPC-vs-peer equivalence tests for root-list and exclusion-list submissions.

### Testing
- `go test ./ethclient -run 'TestSubmitSignedGovernanceLists|TestToFilterArg'`
- `go test ./internal/web3ext`
- `go test ./cmd/utils -run 'TestFilterProtectedAPIs|Test_SplitTagsFlag'`
- `go test ./governance -run 'TestSubmitSignedRootList|TestSubmitSignedExclusionList'`
- `go test ./governance -run 'TestSubmitSigned(RootList|ExclusionList)EquivalentToPeerImport|TestSubmitSignedRootList|TestSubmitSignedExclusionList'`
- `go test ./governance ./ethclient ./internal/web3ext ./cmd/utils`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c021d90d-78d6-43d0-af89-7f5f63ff5a7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c021d90d-78d6-43d0-af89-7f5f63ff5a7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

