### PR TITLE
Fix external L0 CI failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,14 @@ When an agent considers its assigned issue complete:
 - Mark the pull request as ready for review.
 - Comment on the issue with a link to the pull request, or explain why the issue is complete without a pull request.
 - Move the issue to `In review` on the project board.
+
+## Pre-merge QA
+
+Before considering governance or RPC work ready for review, run the narrow checks that match the changed packages and include CI-like coverage for the affected area. For external L0 governance changes, use at least:
+
+- `go test -timeout=20m -p 1 ./governance`
+- `go test ./governance ./ethclient ./internal/web3ext ./cmd/utils`
+- `go test ./governance -run '^$'`
+- `go run build/ci.go lint` when the local environment has the same native dependencies as CI, including `blst` headers.
+
+Automated tests must not depend on live testnets, public RPC endpoints, or other external networks. Use in-process RPC servers, generated chains, fixtures, and mocks instead.

--- a/governance/api.go
+++ b/governance/api.go
@@ -207,10 +207,6 @@ func (s *RootManager) validatePublicSubmissionAllowed(list interface{}) error {
 	return nil
 }
 
-func (s *RootManager) isProposalQuotaDisabled() bool {
-	return s.ProposalQuotaMax == 0
-}
-
 func (a *GovernanceAPI) AcceptQuarantinedExclusionList(hash *common.Hash) error {
 	return a.gov.RootManager.acceptQuarantinedExclusionSet(hash)
 }

--- a/governance/handler_test.go
+++ b/governance/handler_test.go
@@ -752,10 +752,9 @@ func TestSubmitSignedExclusionListEquivalentToPeerImport(t *testing.T) {
 			compareStates: true,
 		},
 		{
-			name:      "threshold upgrade",
-			initChain: true,
+			name: "threshold upgrade",
 			list: func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList {
-				return signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, defNumAccounts-1, true, 6000)
+				return signedActiveExclusionList(t, rm, defNumAccounts-1, true)
 			},
 			compareStates: true,
 		},
@@ -1066,10 +1065,9 @@ func TestImportExclusionList(t *testing.T) {
 			},
 		},
 		{
-			name:      "threshold signatures upgrade active list",
-			initChain: true,
+			name: "threshold signatures upgrade active list",
 			list: func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList {
-				return signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, defNumAccounts-1, true, 6000)
+				return signedActiveExclusionList(t, rm, defNumAccounts-1, true)
 			},
 			assertAfterImport: func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList) {
 				if rm.activeExSet == nil || rm.activeExSet.hash != list.Hash {
@@ -1265,9 +1263,8 @@ func TestSubmitSignedExclusionList(t *testing.T) {
 		{
 			name: "threshold signatures upgrade active list",
 			list: func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList {
-				return signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, defNumAccounts-1, true, 6000)
+				return signedActiveExclusionList(t, rm, defNumAccounts-1, true)
 			},
-			initChain: true,
 			assertAfterSubmit: func(t *testing.T, rm *TestRootManager, list common.ValidatorExclusionList, hash common.Hash, err error) {
 				if err != nil {
 					t.Fatalf("SubmitSignedExclusionList returned error: %v", err)
@@ -1892,4 +1889,35 @@ func signedExclusionList(t *testing.T, rm *TestRootManager, timestamp uint64, va
 	}
 
 	return exclusionList
+}
+
+func signedActiveExclusionListWithTimestamp(t *testing.T, rm *TestRootManager, timestamp uint64, signersCount int, signByAlias bool) common.ValidatorExclusionList {
+	list := rm.activeExSet.copy().makeList()
+	list.Timestamp = timestamp
+	list.Signatures = nil
+	list.Hash = common.Hash{}
+	set, err := newExclusionSet(&list)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	privateKeys := make([]*ecdsa.PrivateKey, 0, signersCount)
+	if signByAlias {
+		privateKeys = append(privateKeys, rm.aliasPrivateKeys[:signersCount]...)
+	} else {
+		privateKeys = append(privateKeys, rm.rootPrivateKeys[:signersCount]...)
+	}
+	for _, key := range privateKeys {
+		sig, err := crypto.Sign(set.hash.Bytes(), key)
+		if err != nil {
+			t.Error(errors.Wrap(err, "failed to sign hash"))
+		}
+		list.Signatures = append(list.Signatures, sig)
+	}
+	list.Hash = set.hash
+	return list
+}
+
+func signedActiveExclusionList(t *testing.T, rm *TestRootManager, signersCount int, signByAlias bool) common.ValidatorExclusionList {
+	return signedActiveExclusionListWithTimestamp(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), signersCount, signByAlias)
 }

--- a/governance/root_manager.go
+++ b/governance/root_manager.go
@@ -46,7 +46,6 @@ var (
 	errExclusionListQuotaExceeded = errors.New("exclusion list quota exceeded")
 
 	errPublicGovernanceSubmissionDisabled = errors.New("public governance submission is disabled")
-	errGovernanceSubmissionTooLarge       = errors.New("governance submission is too large")
 )
 
 // RootManager stores root and exclusion lists.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Removes unused public-submission symbols that failed GitLab lint.
- Optimizes exclusion-list threshold tests to avoid unnecessary 5000-block chain setup while keeping quarantine coverage intact.
- Documents pre-merge QA checks and the no-live-testnet rule in `AGENTS.md`.

### Testing
- `go test -timeout=20m -run 'TestSubmitSignedExclusionList|TestSubmitSignedExclusionListEquivalentToPeerImport|TestImportExclusionList|TestQuarantineExclusionSet' -v ./governance`
- `go test -timeout=20m -p 1 ./governance`
- `go test ./governance ./ethclient ./internal/web3ext ./cmd/utils`
- `go test ./governance -run '^$'`

### Notes
- Local `go run build/ci.go lint` progresses past the GitLab unused-symbol failures but is blocked in this environment by missing vendored `blst.h`; the GitLab lint image did not hit that blocker.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c021d90d-78d6-43d0-af89-7f5f63ff5a7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c021d90d-78d6-43d0-af89-7f5f63ff5a7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

