### PR TITLE
Fix exclusion-list quarantine diff check

### DIFF
--- a/governance/root_manager.go
+++ b/governance/root_manager.go
@@ -1276,19 +1276,45 @@ func (s *RootManager) startQuarantineRoutine() {
 		}
 
 		// send proposed to quarantine if meets criteria
-		if s.proposedExSet != nil {
-			if s.isExclusionSetMeetsQuarantineCriteria(s.proposedExSet.earliestBlock()) {
-				if err := s.initiateExclusionSetQuarantine(s.proposedExSet); err != nil {
-					log.Error("Failed to quarantine exclusion set", "err", err)
-				}
-				s.proposedExSet = nil
-				s.db.deleteProposedExclusionSet()
-			}
-		}
+		s.quarantineProposedExclusionSetIfNeeded()
 
 		// notify if there's anything in quarantine
 		s.notifyQuarantine()
 	}
+}
+
+func (s *RootManager) quarantineProposedExclusionSetIfNeeded() {
+	s.exLock.Lock()
+	defer s.exLock.Unlock()
+
+	if s.proposedExSet == nil {
+		return
+	}
+
+	earliestBlock, ok := s.proposedExclusionSetRewindBlock()
+	if !ok || !s.isExclusionSetMeetsQuarantineCriteria(earliestBlock) {
+		return
+	}
+
+	if err := s.initiateExclusionSetQuarantine(s.proposedExSet); err != nil {
+		log.Error("Failed to quarantine exclusion set", "err", err)
+	}
+	s.proposedExSet = nil
+	s.db.deleteProposedExclusionSet()
+}
+
+// proposedExclusionSetRewindBlock returns the earliest block that would need
+// revalidation if the proposed set replaced the active set.
+func (s *RootManager) proposedExclusionSetRewindBlock() (uint64, bool) {
+	if s.activeExSet == nil {
+		return s.proposedExSet.earliestBlock(), true
+	}
+
+	diff := s.proposedExSet.addrToBlockRangeExclusiveDiff(s.activeExSet)
+	if len(diff) == 0 {
+		return 0, false
+	}
+	return s.proposedExSet.earliestBlockFromDiff(s.activeExSet), true
 }
 
 func (s *RootManager) stop() {

--- a/governance/root_manager_test.go
+++ b/governance/root_manager_test.go
@@ -906,3 +906,71 @@ func TestQuarantineExclusionSet(t *testing.T) {
 	}
 	assert.Lenf(t, qSets, 0, "Quarantine must be empty after exclusion set is accepted")
 }
+
+func TestProposedExclusionSetQuarantineUsesDiff(t *testing.T) {
+	earliestBlock := uint64(2)
+
+	rm := newTestRootManager(t, true, false)
+	bc := newTestChain(t, rm.RootManager)
+	defer bc.Stop()
+	rm.InitBlockChain(bc)
+	rm.setMaxRewindLimit(100)
+
+	t.Run("timestamp only update is not quarantined", func(t *testing.T) {
+		list := rm.activeExSet.copy().makeList()
+		list.Timestamp++
+		list.Signatures = nil
+		list.Hash = common.Hash{}
+
+		set, err := newExclusionSet(&list)
+		if err != nil {
+			t.Fatalf("Can't create timestamp-only exclusion set: %v", err)
+		}
+		rm.signExclusionSet(set)
+		rm.proposedExSet = set
+
+		rm.quarantineProposedExclusionSetIfNeeded()
+
+		if rm.proposedExSet == nil || rm.proposedExSet.hash != set.hash {
+			t.Fatalf("timestamp-only proposed exclusion set was quarantined or removed")
+		}
+		qSets, err := rm.db.getExclusionSetsFromQuarantine()
+		if err != nil {
+			t.Fatalf("Failed to get exclusion sets from quarantine: %v", err)
+		}
+		if len(qSets) != 0 {
+			t.Fatalf("timestamp-only proposed exclusion set was quarantined: %v", qSets)
+		}
+	})
+
+	t.Run("changed range is quarantined", func(t *testing.T) {
+		list := rm.activeExSet.copy().makeList()
+		list.Timestamp++
+		list.Signatures = nil
+		list.Hash = common.Hash{}
+		list.Validators = append(list.Validators, common.ExcludedValidator{
+			Address: common.HexToAddress("0x2B01035cDa82a02fb135EBd68676Fa17FdcAD365"),
+			Block:   earliestBlock,
+		})
+
+		set, err := newExclusionSet(&list)
+		if err != nil {
+			t.Fatalf("Can't create changed exclusion set: %v", err)
+		}
+		rm.signExclusionSet(set)
+		rm.proposedExSet = set
+
+		rm.quarantineProposedExclusionSetIfNeeded()
+
+		if rm.proposedExSet != nil {
+			t.Fatalf("changed proposed exclusion set was not removed after quarantine")
+		}
+		qSets, err := rm.db.getExclusionSetsFromQuarantine()
+		if err != nil {
+			t.Fatalf("Failed to get exclusion sets from quarantine: %v", err)
+		}
+		if len(qSets) != 1 || qSets[0].hash != set.hash {
+			t.Fatalf("changed proposed exclusion set was not quarantined, got %v", qSets)
+		}
+	})
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Updates proposed exclusion-list quarantine checks to use the diff against the active exclusion set instead of the proposed list's oldest ban block.
- Keeps timestamp-only exclusion-list refreshes out of quarantine while preserving quarantine behavior for real validator/range changes.
- Adds regression coverage for timestamp-only proposed lists and changed-range proposed lists.

### Testing
- `go test ./governance -run 'Test(ProposedExclusionSetQuarantineUsesDiff|QuarantineExclusionSet)'`
- `go test -timeout=20m -p 1 ./governance`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c021d90d-78d6-43d0-af89-7f5f63ff5a7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c021d90d-78d6-43d0-af89-7f5f63ff5a7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

