### PR TITLE
Format governance proposal status struct

### DIFF
--- a/governance/proposal_status.go
+++ b/governance/proposal_status.go
@@ -27,14 +27,14 @@ type GovernanceProposalThreshold struct {
 
 // GovernanceProposalStatus is the normalized status of a root-list or exclusion-list proposal hash.
 type GovernanceProposalStatus struct {
-	ProposalType   string                        `json:"proposalType"`
-	Phase          string                        `json:"phase"`
-	Hash           common.Hash                   `json:"hash"`
-	Timestamp      uint64                        `json:"timestamp"`
-	Signers        []common.Address              `json:"signers"`
-	Threshold      GovernanceProposalThreshold   `json:"threshold"`
-	NeedsSignature bool                          `json:"needsSignature"`
-	QueriedSigner  common.Address                `json:"queriedSigner"`
+	ProposalType   string                      `json:"proposalType"`
+	Phase          string                      `json:"phase"`
+	Hash           common.Hash                 `json:"hash"`
+	Timestamp      uint64                      `json:"timestamp"`
+	Signers        []common.Address            `json:"signers"`
+	Threshold      GovernanceProposalThreshold `json:"threshold"`
+	NeedsSignature bool                        `json:"needsSignature"`
+	QueriedSigner  common.Address              `json:"queriedSigner"`
 }
 
 func (a *GovernancePublicAPI) GetGovernanceProposalStatus(proposalType string, hash common.Hash, signer common.Address) (GovernanceProposalStatus, error) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Format `governance/proposal_status.go` so the `GovernanceProposalStatus` struct satisfies Go formatting/goimports checks.

### Testing
- `test -z "$(gofmt -l governance/proposal_status.go)"`
- `go test ./governance -run TestGetGovernanceProposalStatus`
- `go run golang.org/x/tools/cmd/goimports@latest -l governance/proposal_status.go`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c88121c-e6e7-4f22-ae87-89e0a05fa633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c88121c-e6e7-4f22-ae87-89e0a05fa633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

