### PR TITLE
Epic B: typed L0 governance dapp APIs (EIP-712, capabilities, alias errors)

### DIFF
--- a/common/governance_capabilities.go
+++ b/common/governance_capabilities.go
@@ -1,0 +1,52 @@
+package common
+
+const (
+	// L0GovernanceCapabilitiesSchemaVersion is the schema version of govPub_l0GovernanceCapabilities responses.
+	L0GovernanceCapabilitiesSchemaVersion = 1
+
+	// GovernanceSigningSchemeRawListHash is legacy ECDSA over the deterministic list hash.
+	GovernanceSigningSchemeRawListHash = "raw-list-hash"
+	// GovernanceSigningSchemeEIP712V1 is EIP-712 typed data (eth_signTypedData_v4).
+	GovernanceSigningSchemeEIP712V1 = "eip712-v1"
+
+	// GovernanceSigningPayloadVersionEIP712V1 is the signing-payload / typed-data version label.
+	GovernanceSigningPayloadVersionEIP712V1 = "eip712-v1"
+)
+
+// L0GovernanceCapabilities is returned by govPub_l0GovernanceCapabilities.
+type L0GovernanceCapabilities struct {
+	SchemaVersion             uint   `json:"schemaVersion"`
+	NetworkID                 uint64 `json:"networkId"`
+	ExternalSubmissionEnabled bool   `json:"externalSubmissionEnabled"`
+	DisableReason             string `json:"disableReason,omitempty"`
+
+	// QgovTypedRelayVersion is set when the node registers qgov/6 typed attestation relay (separate from RPC flags).
+	QgovTypedRelayVersion *uint `json:"qgovTypedRelayVersion,omitempty"`
+
+	RootList      L0GovernanceProposalCapabilities `json:"rootList"`
+	ExclusionList L0GovernanceProposalCapabilities `json:"exclusionList"`
+
+	ProposalStatus                       bool `json:"proposalStatus"`
+	ProposalStatusRequiredSigningAddress bool `json:"proposalStatusRequiredSigningAddress"`
+
+	// AliasSigningRequired is true when the active root set has at least one root with a distinct alias address.
+	AliasSigningRequired bool `json:"aliasSigningRequired"`
+
+	SigningPayload L0GovernanceSigningPayloadCapabilities `json:"signingPayload"`
+}
+
+// L0GovernanceProposalCapabilities describes submission and verification options for one proposal kind.
+type L0GovernanceProposalCapabilities struct {
+	RawSubmit              bool     `json:"rawSubmit"`
+	TypedSubmit            bool     `json:"typedSubmit"`
+	SigningSchemes         []string `json:"signingSchemes"`
+	SigningPayloadVersions []string `json:"signingPayloadVersions"`
+}
+
+// L0GovernanceSigningPayloadCapabilities documents EIP-712 domain metadata for wallet signing.
+type L0GovernanceSigningPayloadCapabilities struct {
+	Domain                   string `json:"domain"`
+	Version                  string `json:"version"`
+	VerifyingContract        string `json:"verifyingContract"`
+	SigningPayloadWithDigest bool   `json:"signingPayloadWithDigest"`
+}

--- a/common/governance_eip712.go
+++ b/common/governance_eip712.go
@@ -1,0 +1,36 @@
+package common
+
+// GovernanceEIP712TypedData is the JSON shape returned by govPub signing-payload RPCs
+// for eth_signTypedData_v4 (types, primaryType, domain, message).
+type GovernanceEIP712TypedData struct {
+	Types       map[string][]GovernanceEIP712TypeField `json:"types"`
+	PrimaryType string                                 `json:"primaryType"`
+	Domain      GovernanceEIP712Domain                 `json:"domain"`
+	Message     map[string]interface{}                 `json:"message"`
+}
+
+// GovernanceEIP712TypeField is one field in an EIP-712 type definition.
+type GovernanceEIP712TypeField struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+// GovernanceEIP712Domain is the EIP-712 domain separator for L0 governance.
+type GovernanceEIP712Domain struct {
+	Name              string `json:"name"`
+	Version           string `json:"version"`
+	ChainId           string `json:"chainId"`
+	VerifyingContract string `json:"verifyingContract"`
+}
+
+// RootListSigningPayloadV1WithDigest bundles EIP-712 typed data and the wallet signing hash.
+type RootListSigningPayloadV1WithDigest struct {
+	TypedData GovernanceEIP712TypedData `json:"typedData"`
+	Digest    Hash                      `json:"digest"`
+}
+
+// ExclusionListSigningPayloadV1WithDigest is the exclusion-list counterpart.
+type ExclusionListSigningPayloadV1WithDigest struct {
+	TypedData GovernanceEIP712TypedData `json:"typedData"`
+	Digest    Hash                      `json:"digest"`
+}

--- a/common/governance_signing_payload.go
+++ b/common/governance_signing_payload.go
@@ -44,19 +44,6 @@ type ExclusionListSigningPayload struct {
 	Validators []ExcludedValidator       `json:"validators"`
 }
 
-// RootListSigningPayloadV1WithDigest bundles the canonical v1 typed payload and the 32-byte digest
-// that wallets sign (Payload.Hash()). JSON-RPC cannot return multiple values; use this struct for WithDigest APIs.
-type RootListSigningPayloadV1WithDigest struct {
-	Payload RootListSigningPayload `json:"payload"`
-	Digest  Hash                   `json:"digest"`
-}
-
-// ExclusionListSigningPayloadV1WithDigest is the exclusion-list counterpart of RootListSigningPayloadV1WithDigest.
-type ExclusionListSigningPayloadV1WithDigest struct {
-	Payload ExclusionListSigningPayload `json:"payload"`
-	Digest  Hash                        `json:"digest"`
-}
-
 func NewRootListSigningPayloadV1(chainID uint64, list RootList) RootListSigningPayload {
 	return RootListSigningPayload{
 		Metadata: GovernanceSigningMetadata{
@@ -85,10 +72,14 @@ func NewExclusionListSigningPayloadV1(chainID uint64, list ValidatorExclusionLis
 	}
 }
 
+// Hash returns the legacy custom canonical digest. Wallet signing and typed verification
+// use EIP-712 (see governance/eip712.go and govPub_signingPayload* RPCs).
 func (p RootListSigningPayload) Hash() Hash {
 	return keccakHash(p.canonicalBytes())
 }
 
+// Hash returns the legacy custom canonical digest. Wallet signing and typed verification
+// use EIP-712 (see governance/eip712.go and govPub_signingPayload* RPCs).
 func (p ExclusionListSigningPayload) Hash() Hash {
 	return keccakHash(p.canonicalBytes())
 }

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -810,14 +810,14 @@ func (ec *Client) SubmitSignedExclusionList(ctx context.Context, list common.Val
 	return res, err
 }
 
-func (ec *Client) SigningPayloadRootListV1(ctx context.Context, list common.RootList) (common.RootListSigningPayload, error) {
-	var res common.RootListSigningPayload
+func (ec *Client) SigningPayloadRootListV1(ctx context.Context, list common.RootList) (common.GovernanceEIP712TypedData, error) {
+	var res common.GovernanceEIP712TypedData
 	err := ec.c.CallContext(ctx, &res, "govPub_signingPayloadRootListV1", list)
 	return res, err
 }
 
-func (ec *Client) SigningPayloadExclusionListV1(ctx context.Context, list common.ValidatorExclusionList) (common.ExclusionListSigningPayload, error) {
-	var res common.ExclusionListSigningPayload
+func (ec *Client) SigningPayloadExclusionListV1(ctx context.Context, list common.ValidatorExclusionList) (common.GovernanceEIP712TypedData, error) {
+	var res common.GovernanceEIP712TypedData
 	err := ec.c.CallContext(ctx, &res, "govPub_signingPayloadExclusionListV1", list)
 	return res, err
 }

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -798,6 +798,12 @@ func (ec *Client) GetProposedRootList(ctx context.Context) (governance.RootList,
 	return res, err
 }
 
+func (ec *Client) L0GovernanceCapabilities(ctx context.Context) (common.L0GovernanceCapabilities, error) {
+	var res common.L0GovernanceCapabilities
+	err := ec.c.CallContext(ctx, &res, "govPub_l0GovernanceCapabilities")
+	return res, err
+}
+
 func (ec *Client) SubmitSignedRootList(ctx context.Context, list common.RootList) (common.Hash, error) {
 	var res common.Hash
 	err := ec.c.CallContext(ctx, &res, "govPub_submitSignedRootList", list)

--- a/governance/api.go
+++ b/governance/api.go
@@ -199,85 +199,58 @@ func (a *GovernancePublicAPI) SubmitTypedSignedExclusionList(list common.Validat
 	return a.gov.handler.ProcessTypedSignedExclusionList(list)
 }
 
-// SigningPayloadRootListV1 returns the canonical QGOV v1 typed signing payload for a root-list proposal.
+// SigningPayloadRootListV1 returns EIP-712 typed data for eth_signTypedData_v4 (QGOV L0 root-list v1).
 // The node uses its configured network id as chainId (same as typed-signature verification).
 // Signatures on the input list are ignored. Proposal content must match list.Hash when hash is set.
-func (a *GovernancePublicAPI) SigningPayloadRootListV1(list common.RootList) (common.RootListSigningPayload, error) {
-	return a.rootListSigningPayloadV1(list)
+func (a *GovernancePublicAPI) SigningPayloadRootListV1(list common.RootList) (common.GovernanceEIP712TypedData, error) {
+	if err := a.gov.RootManager.validateGovPubProposalInputSize(list); err != nil {
+		return common.GovernanceEIP712TypedData{}, err
+	}
+	return buildRootListEIP712(a.gov.RootManager.networkId, list)
 }
 
-// SigningPayloadRootListV1WithDigest returns the same payload as SigningPayloadRootListV1 plus the signing digest (Payload.Hash()).
+// SigningPayloadRootListV1WithDigest returns EIP-712 typed data plus the wallet signing hash (TypedDataAndHash).
 func (a *GovernancePublicAPI) SigningPayloadRootListV1WithDigest(list common.RootList) (common.RootListSigningPayloadV1WithDigest, error) {
-	p, err := a.rootListSigningPayloadV1(list)
+	typedData, err := a.SigningPayloadRootListV1(list)
 	if err != nil {
 		return common.RootListSigningPayloadV1WithDigest{}, err
 	}
-	return common.RootListSigningPayloadV1WithDigest{Payload: p, Digest: p.Hash()}, nil
-}
-
-func (a *GovernancePublicAPI) rootListSigningPayloadV1(list common.RootList) (common.RootListSigningPayload, error) {
-	if err := a.gov.RootManager.validateGovPubProposalInputSize(list); err != nil {
-		return common.RootListSigningPayload{}, err
-	}
-
-	unsigned := list
-	unsigned.Signatures = nil
-
-	set, err := newRootSet(&unsigned)
+	td, err := fromPublicEIP712TypedData(typedData)
 	if err != nil {
-		return common.RootListSigningPayload{}, errors.Wrap(err, "invalid root list proposal")
+		return common.RootListSigningPayloadV1WithDigest{}, err
 	}
-	if set == nil {
-		return common.RootListSigningPayload{}, errors.New("root list has no nodes")
+	digest, err := eip712Digest(td)
+	if err != nil {
+		return common.RootListSigningPayloadV1WithDigest{}, err
 	}
-
-	rm := a.gov.RootManager
-	return common.NewRootListSigningPayloadV1(rm.networkId, common.RootList{
-		Timestamp: set.timestamp,
-		Nodes:     set.rootAddresses,
-		Hash:      set.hash,
-	}), nil
+	return common.RootListSigningPayloadV1WithDigest{TypedData: typedData, Digest: digest}, nil
 }
 
-// SigningPayloadExclusionListV1 returns the canonical QGOV v1 typed signing payload for an exclusion-list proposal.
+// SigningPayloadExclusionListV1 returns EIP-712 typed data for eth_signTypedData_v4 (QGOV L0 exclusion-list v1).
 // The node uses its configured network id as chainId (same as typed-signature verification).
 // Signatures on the input list are ignored. When list.Hash is non-zero it must match the computed proposal hash.
-func (a *GovernancePublicAPI) SigningPayloadExclusionListV1(list common.ValidatorExclusionList) (common.ExclusionListSigningPayload, error) {
-	return a.exclusionListSigningPayloadV1(list)
+func (a *GovernancePublicAPI) SigningPayloadExclusionListV1(list common.ValidatorExclusionList) (common.GovernanceEIP712TypedData, error) {
+	if err := a.gov.RootManager.validateGovPubProposalInputSize(list); err != nil {
+		return common.GovernanceEIP712TypedData{}, err
+	}
+	return buildExclusionListEIP712(a.gov.RootManager.networkId, list)
 }
 
-// SigningPayloadExclusionListV1WithDigest returns the same payload as SigningPayloadExclusionListV1 plus the signing digest (Payload.Hash()).
+// SigningPayloadExclusionListV1WithDigest returns EIP-712 typed data plus the wallet signing hash (TypedDataAndHash).
 func (a *GovernancePublicAPI) SigningPayloadExclusionListV1WithDigest(list common.ValidatorExclusionList) (common.ExclusionListSigningPayloadV1WithDigest, error) {
-	p, err := a.exclusionListSigningPayloadV1(list)
+	typedData, err := a.SigningPayloadExclusionListV1(list)
 	if err != nil {
 		return common.ExclusionListSigningPayloadV1WithDigest{}, err
 	}
-	return common.ExclusionListSigningPayloadV1WithDigest{Payload: p, Digest: p.Hash()}, nil
-}
-
-func (a *GovernancePublicAPI) exclusionListSigningPayloadV1(list common.ValidatorExclusionList) (common.ExclusionListSigningPayload, error) {
-	if err := a.gov.RootManager.validateGovPubProposalInputSize(list); err != nil {
-		return common.ExclusionListSigningPayload{}, err
-	}
-
-	unsigned := list
-	unsigned.Signatures = nil
-
-	set, err := newExclusionSet(&unsigned)
+	td, err := fromPublicEIP712TypedData(typedData)
 	if err != nil {
-		return common.ExclusionListSigningPayload{}, errors.Wrap(err, "invalid exclusion list proposal")
+		return common.ExclusionListSigningPayloadV1WithDigest{}, err
 	}
-	if set == nil {
-		return common.ExclusionListSigningPayload{}, errors.New("invalid exclusion list proposal")
+	digest, err := eip712Digest(td)
+	if err != nil {
+		return common.ExclusionListSigningPayloadV1WithDigest{}, err
 	}
-	if list.Hash != (common.Hash{}) && set.hash != list.Hash {
-		return common.ExclusionListSigningPayload{}, errHashMismatch
-	}
-
-	rm := a.gov.RootManager
-	source := set.makeList()
-	source.Signatures = nil
-	return common.NewExclusionListSigningPayloadV1(rm.networkId, source), nil
+	return common.ExclusionListSigningPayloadV1WithDigest{TypedData: typedData, Digest: digest}, nil
 }
 
 func (s *RootManager) validateGovPubProposalInputSize(list interface{}) error {

--- a/governance/capabilities.go
+++ b/governance/capabilities.go
@@ -1,0 +1,75 @@
+package governance
+
+import (
+	"gitlab.com/q-dev/q-client/common"
+)
+
+func (a *GovernancePublicAPI) L0GovernanceCapabilities() (common.L0GovernanceCapabilities, error) {
+	rm := a.gov.RootManager
+	externalEnabled := !rm.DisablePublicSubmission
+
+	cap := common.L0GovernanceCapabilities{
+		SchemaVersion:                        common.L0GovernanceCapabilitiesSchemaVersion,
+		NetworkID:                            rm.networkId,
+		ExternalSubmissionEnabled:            externalEnabled,
+		RootList:                             proposalCapabilities(externalEnabled),
+		ExclusionList:                        proposalCapabilities(externalEnabled),
+		ProposalStatus:                       true,
+		ProposalStatusRequiredSigningAddress: true,
+		AliasSigningRequired:                 rm.hasDistinctRootAliases(),
+		SigningPayload: common.L0GovernanceSigningPayloadCapabilities{
+			Domain:                   common.GovernanceSigningDomain,
+			Version:                  common.GovernanceSigningVersionV1,
+			VerifyingContract:        governanceEIP712ZeroContract,
+			SigningPayloadWithDigest: true,
+		},
+	}
+
+	if !externalEnabled {
+		cap.DisableReason = errPublicGovernanceSubmissionDisabled.Error()
+	}
+
+	if advertisesQgovTypedRelay() {
+		v := uint(qgov6)
+		cap.QgovTypedRelayVersion = &v
+	}
+
+	return cap, nil
+}
+
+func proposalCapabilities(externalSubmissionEnabled bool) common.L0GovernanceProposalCapabilities {
+	schemes := []string{
+		common.GovernanceSigningSchemeRawListHash,
+		common.GovernanceSigningSchemeEIP712V1,
+	}
+	payloadVersions := []string{common.GovernanceSigningPayloadVersionEIP712V1}
+
+	return common.L0GovernanceProposalCapabilities{
+		RawSubmit:              externalSubmissionEnabled,
+		TypedSubmit:            externalSubmissionEnabled,
+		SigningSchemes:         schemes,
+		SigningPayloadVersions: payloadVersions,
+	}
+}
+
+func advertisesQgovTypedRelay() bool {
+	for _, version := range ProtocolVersions {
+		if version == qgov6 {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *RootManager) hasDistinctRootAliases() bool {
+	active := s.getActiveRootSet(true)
+	if active == nil {
+		return false
+	}
+	for root, alias := range active.aliases {
+		if root != alias {
+			return true
+		}
+	}
+	return false
+}

--- a/governance/capabilities_test.go
+++ b/governance/capabilities_test.go
@@ -1,0 +1,61 @@
+package governance
+
+import (
+	"reflect"
+	"testing"
+
+	"gitlab.com/q-dev/q-client/common"
+)
+
+func TestL0GovernanceCapabilities(t *testing.T) {
+	t.Run("enabled", func(t *testing.T) {
+		rm := newTestRootManager(t, false, true)
+		api := newGovernancePublicAPI(t, rm.RootManager)
+
+		cap, err := api.L0GovernanceCapabilities()
+		if err != nil {
+			t.Fatalf("L0GovernanceCapabilities: %v", err)
+		}
+		if !cap.ExternalSubmissionEnabled {
+			t.Fatal("expected external submission enabled")
+		}
+		if cap.QgovTypedRelayVersion == nil || *cap.QgovTypedRelayVersion != qgov6 {
+			t.Fatalf("qgovTypedRelayVersion %+v want %d", cap.QgovTypedRelayVersion, qgov6)
+		}
+		assertProposalCaps(t, cap.RootList, true)
+	})
+
+	t.Run("disabled external submission", func(t *testing.T) {
+		rm := newTestRootManager(t, false, true)
+		rm.DisablePublicSubmission = true
+		api := newGovernancePublicAPI(t, rm.RootManager)
+
+		cap, err := api.L0GovernanceCapabilities()
+		if err != nil {
+			t.Fatalf("L0GovernanceCapabilities: %v", err)
+		}
+		if cap.ExternalSubmissionEnabled {
+			t.Fatal("expected external submission disabled")
+		}
+		if cap.DisableReason != errPublicGovernanceSubmissionDisabled.Error() {
+			t.Fatalf("disableReason %q", cap.DisableReason)
+		}
+		if cap.RootList.RawSubmit || cap.RootList.TypedSubmit {
+			t.Fatal("submit flags must be false when external submission is disabled")
+		}
+	})
+}
+
+func assertProposalCaps(t *testing.T, got common.L0GovernanceProposalCapabilities, submitEnabled bool) {
+	t.Helper()
+	if got.RawSubmit != submitEnabled || got.TypedSubmit != submitEnabled {
+		t.Fatalf("submit flags raw=%v typed=%v want %v", got.RawSubmit, got.TypedSubmit, submitEnabled)
+	}
+	wantSchemes := []string{
+		common.GovernanceSigningSchemeRawListHash,
+		common.GovernanceSigningSchemeEIP712V1,
+	}
+	if !reflect.DeepEqual(got.SigningSchemes, wantSchemes) {
+		t.Fatalf("signingSchemes %#v", got.SigningSchemes)
+	}
+}

--- a/governance/eip712.go
+++ b/governance/eip712.go
@@ -1,0 +1,252 @@
+package governance
+
+import (
+	"fmt"
+	"math/big"
+
+	"gitlab.com/q-dev/q-client/common"
+	"gitlab.com/q-dev/q-client/common/math"
+	"gitlab.com/q-dev/q-client/crypto"
+	"gitlab.com/q-dev/q-client/signer/core/apitypes"
+)
+
+const governanceEIP712ZeroContract = "0x0000000000000000000000000000000000000000"
+
+var (
+	eip712DomainType = []apitypes.Type{
+		{Name: "name", Type: "string"},
+		{Name: "version", Type: "string"},
+		{Name: "chainId", Type: "uint256"},
+		{Name: "verifyingContract", Type: "address"},
+	}
+	rootListProposalType = []apitypes.Type{
+		{Name: "proposalType", Type: "string"},
+		{Name: "timestamp", Type: "uint256"},
+		{Name: "payloadHash", Type: "bytes32"},
+		{Name: "nodes", Type: "address[]"},
+	}
+	excludedValidatorType = []apitypes.Type{
+		{Name: "address", Type: "address"},
+		{Name: "block", Type: "uint256"},
+		{Name: "endBlock", Type: "uint256"},
+	}
+	exclusionListProposalType = []apitypes.Type{
+		{Name: "proposalType", Type: "string"},
+		{Name: "timestamp", Type: "uint256"},
+		{Name: "payloadHash", Type: "bytes32"},
+		{Name: "validators", Type: "QGOVL0ExcludedValidator[]"},
+	}
+)
+
+func governanceEIP712Domain(chainID uint64) apitypes.TypedDataDomain {
+	return apitypes.TypedDataDomain{
+		Name:              common.GovernanceSigningDomain,
+		Version:           common.GovernanceSigningVersionV1,
+		ChainId:           math.NewHexOrDecimal256(int64(chainID)),
+		VerifyingContract: governanceEIP712ZeroContract,
+	}
+}
+
+func rootListEIP712TypedData(chainID uint64, timestamp uint64, payloadHash common.Hash, nodes []common.Address) apitypes.TypedData {
+	nodeAddrs := make([]interface{}, len(nodes))
+	for i, node := range nodes {
+		nodeAddrs[i] = node.Hex()
+	}
+
+	return apitypes.TypedData{
+		Types: apitypes.Types{
+			"EIP712Domain":                          eip712DomainType,
+			common.GovernanceEIP712RootListTypeName: rootListProposalType,
+		},
+		PrimaryType: common.GovernanceEIP712RootListTypeName,
+		Domain:      governanceEIP712Domain(chainID),
+		Message: map[string]interface{}{
+			"proposalType": common.GovernanceProposalTypeRootList,
+			"timestamp":    uint256Value(timestamp),
+			"payloadHash":  payloadHash.Hex(),
+			"nodes":        nodeAddrs,
+		},
+	}
+}
+
+func exclusionListEIP712TypedData(chainID uint64, timestamp uint64, payloadHash common.Hash, validators []common.ExcludedValidator) apitypes.TypedData {
+	entries := make([]interface{}, len(validators))
+	for i, val := range validators {
+		entries[i] = map[string]interface{}{
+			"address":  val.Address.Hex(),
+			"block":    uint256Value(val.Block),
+			"endBlock": uint256Value(val.EndBlock),
+		}
+	}
+
+	return apitypes.TypedData{
+		Types: apitypes.Types{
+			"EIP712Domain":                               eip712DomainType,
+			"QGOVL0ExcludedValidator":                    excludedValidatorType,
+			common.GovernanceEIP712ExclusionListTypeName: exclusionListProposalType,
+		},
+		PrimaryType: common.GovernanceEIP712ExclusionListTypeName,
+		Domain:      governanceEIP712Domain(chainID),
+		Message: map[string]interface{}{
+			"proposalType": common.GovernanceProposalTypeExclusionList,
+			"timestamp":    uint256Value(timestamp),
+			"payloadHash":  payloadHash.Hex(),
+			"validators":   entries,
+		},
+	}
+}
+
+func uint256Value(v uint64) *math.HexOrDecimal256 {
+	return math.NewHexOrDecimal256(int64(v))
+}
+
+func eip712Digest(td apitypes.TypedData) (common.Hash, error) {
+	hash, _, err := apitypes.TypedDataAndHash(td)
+	if err != nil {
+		return common.Hash{}, err
+	}
+	return common.BytesToHash(hash), nil
+}
+
+func buildRootListEIP712(chainID uint64, list common.RootList) (common.GovernanceEIP712TypedData, error) {
+	unsigned := list
+	unsigned.Signatures = nil
+
+	set, err := newRootSet(&unsigned)
+	if err != nil {
+		return common.GovernanceEIP712TypedData{}, err
+	}
+	if set == nil {
+		return common.GovernanceEIP712TypedData{}, fmt.Errorf("root list has no nodes")
+	}
+	if list.Hash != (common.Hash{}) && set.hash != list.Hash {
+		return common.GovernanceEIP712TypedData{}, errHashMismatch
+	}
+
+	td := rootListEIP712TypedData(chainID, set.timestamp, set.hash, set.rootAddresses)
+	return toPublicEIP712TypedData(td), nil
+}
+
+func buildExclusionListEIP712(chainID uint64, list common.ValidatorExclusionList) (common.GovernanceEIP712TypedData, error) {
+	unsigned := list
+	unsigned.Signatures = nil
+
+	set, err := newExclusionSet(&unsigned)
+	if err != nil {
+		return common.GovernanceEIP712TypedData{}, err
+	}
+	if set == nil {
+		return common.GovernanceEIP712TypedData{}, fmt.Errorf("invalid exclusion list proposal")
+	}
+	if list.Hash != (common.Hash{}) && set.hash != list.Hash {
+		return common.GovernanceEIP712TypedData{}, errHashMismatch
+	}
+
+	source := set.makeList()
+	source.Signatures = nil
+	validators := canonicalExcludedValidatorsForEIP712(source.Validators)
+
+	td := exclusionListEIP712TypedData(chainID, set.timestamp, set.hash, validators)
+	return toPublicEIP712TypedData(td), nil
+}
+
+func rootListEIP712Digest(chainID uint64, timestamp uint64, payloadHash common.Hash, nodes []common.Address) (common.Hash, error) {
+	return eip712Digest(rootListEIP712TypedData(chainID, timestamp, payloadHash, nodes))
+}
+
+func exclusionListEIP712Digest(chainID uint64, timestamp uint64, payloadHash common.Hash, validators []common.ExcludedValidator) (common.Hash, error) {
+	return eip712Digest(exclusionListEIP712TypedData(chainID, timestamp, payloadHash, validators))
+}
+
+func verifyRootListEIP712Signature(chainID uint64, set *rootSet, sig []byte) (common.Address, bool) {
+	if chainID == 0 || set == nil {
+		return common.Address{}, false
+	}
+	digest, err := rootListEIP712Digest(chainID, set.timestamp, set.hash, set.rootAddresses)
+	if err != nil {
+		return common.Address{}, false
+	}
+	pubkey, err := crypto.SigToPub(digest.Bytes(), sig)
+	if err != nil {
+		return common.Address{}, false
+	}
+	return crypto.PubkeyToAddress(*pubkey), true
+}
+
+func verifyExclusionListEIP712Signature(chainID uint64, set *exclusionSet, sig []byte) (common.Address, bool) {
+	if chainID == 0 || set == nil {
+		return common.Address{}, false
+	}
+	unsigned := set.makeList()
+	unsigned.Signatures = nil
+	validators := canonicalExcludedValidatorsForEIP712(unsigned.Validators)
+
+	digest, err := exclusionListEIP712Digest(chainID, set.timestamp, set.hash, validators)
+	if err != nil {
+		return common.Address{}, false
+	}
+	pubkey, err := crypto.SigToPub(digest.Bytes(), sig)
+	if err != nil {
+		return common.Address{}, false
+	}
+	return crypto.PubkeyToAddress(*pubkey), true
+}
+
+// canonicalExcludedValidatorsForEIP712 uses the same validator ordering as list parsing.
+func canonicalExcludedValidatorsForEIP712(validators []common.ExcludedValidator) []common.ExcludedValidator {
+	return common.NewExclusionListSigningPayloadV1(0, common.ValidatorExclusionList{Validators: validators}).Validators
+}
+
+func toPublicEIP712TypedData(td apitypes.TypedData) common.GovernanceEIP712TypedData {
+	out := common.GovernanceEIP712TypedData{
+		PrimaryType: td.PrimaryType,
+		Message:     td.Message,
+		Types:       make(map[string][]common.GovernanceEIP712TypeField, len(td.Types)),
+	}
+	for typeName, fields := range td.Types {
+		typedFields := make([]common.GovernanceEIP712TypeField, len(fields))
+		for i, field := range fields {
+			typedFields[i] = common.GovernanceEIP712TypeField{Name: field.Name, Type: field.Type}
+		}
+		out.Types[typeName] = typedFields
+	}
+	chainID := ""
+	if td.Domain.ChainId != nil {
+		chainID = (*big.Int)(td.Domain.ChainId).String()
+	}
+	out.Domain = common.GovernanceEIP712Domain{
+		Name:              td.Domain.Name,
+		Version:           td.Domain.Version,
+		ChainId:           chainID,
+		VerifyingContract: td.Domain.VerifyingContract,
+	}
+	return out
+}
+
+func fromPublicEIP712TypedData(data common.GovernanceEIP712TypedData) (apitypes.TypedData, error) {
+	types := make(apitypes.Types, len(data.Types))
+	for typeName, fields := range data.Types {
+		typedFields := make([]apitypes.Type, len(fields))
+		for i, field := range fields {
+			typedFields[i] = apitypes.Type{Name: field.Name, Type: field.Type}
+		}
+		types[typeName] = typedFields
+	}
+
+	chainID, ok := math.ParseBig256(data.Domain.ChainId)
+	if !ok {
+		return apitypes.TypedData{}, fmt.Errorf("invalid chainId: %s", data.Domain.ChainId)
+	}
+
+	return apitypes.TypedData{
+		Types:       types,
+		PrimaryType: data.PrimaryType,
+		Domain: apitypes.TypedDataDomain{
+			Name:              data.Domain.Name,
+			Version:           data.Domain.Version,
+			ChainId:           (*math.HexOrDecimal256)(chainID),
+			VerifyingContract: data.Domain.VerifyingContract,
+		},
+		Message: data.Message,
+	}, nil
+}

--- a/governance/eip712_test.go
+++ b/governance/eip712_test.go
@@ -1,0 +1,152 @@
+package governance
+
+import (
+	"crypto/ecdsa"
+	"testing"
+
+	"gitlab.com/q-dev/q-client/common"
+	"gitlab.com/q-dev/q-client/crypto"
+	"gitlab.com/q-dev/q-client/signer/core/apitypes"
+)
+
+func signRootListEIP712(t *testing.T, networkID uint64, list common.RootList, key *ecdsa.PrivateKey) []byte {
+	t.Helper()
+
+	unsigned := list
+	unsigned.Signatures = nil
+	set, err := newRootSet(&unsigned)
+	if err != nil {
+		t.Fatalf("newRootSet: %v", err)
+	}
+	if set == nil {
+		t.Fatal("newRootSet returned nil")
+	}
+
+	digest, err := rootListEIP712Digest(networkID, set.timestamp, set.hash, set.rootAddresses)
+	if err != nil {
+		t.Fatalf("rootListEIP712Digest: %v", err)
+	}
+	sig, err := crypto.Sign(digest.Bytes(), key)
+	if err != nil {
+		t.Fatalf("crypto.Sign: %v", err)
+	}
+	return sig
+}
+
+func signRootListEIP712FromTypedData(t *testing.T, td apitypes.TypedData, key *ecdsa.PrivateKey) []byte {
+	t.Helper()
+
+	digest, err := eip712Digest(td)
+	if err != nil {
+		t.Fatalf("eip712Digest: %v", err)
+	}
+	sig, err := crypto.Sign(digest.Bytes(), key)
+	if err != nil {
+		t.Fatalf("crypto.Sign: %v", err)
+	}
+	return sig
+}
+
+func signExclusionListEIP712FromTypedData(t *testing.T, td apitypes.TypedData, key *ecdsa.PrivateKey) []byte {
+	t.Helper()
+
+	digest, err := eip712Digest(td)
+	if err != nil {
+		t.Fatalf("eip712Digest: %v", err)
+	}
+	sig, err := crypto.Sign(digest.Bytes(), key)
+	if err != nil {
+		t.Fatalf("crypto.Sign: %v", err)
+	}
+	return sig
+}
+
+func signExclusionListEIP712(t *testing.T, networkID uint64, list common.ValidatorExclusionList, key *ecdsa.PrivateKey) []byte {
+	t.Helper()
+
+	unsigned := list
+	unsigned.Signatures = nil
+	set, err := newExclusionSet(&unsigned)
+	if err != nil {
+		t.Fatalf("newExclusionSet: %v", err)
+	}
+	if set == nil {
+		t.Fatal("newExclusionSet returned nil")
+	}
+
+	source := set.makeList()
+	source.Signatures = nil
+	validators := canonicalExcludedValidatorsForEIP712(source.Validators)
+
+	digest, err := exclusionListEIP712Digest(networkID, set.timestamp, set.hash, validators)
+	if err != nil {
+		t.Fatalf("exclusionListEIP712Digest: %v", err)
+	}
+	sig, err := crypto.Sign(digest.Bytes(), key)
+	if err != nil {
+		t.Fatalf("crypto.Sign: %v", err)
+	}
+	return sig
+}
+
+func TestRootListEIP712_DeterministicAndDistinctFromCustomDigest(t *testing.T) {
+	list := common.RootList{
+		Timestamp: 1715072400,
+		Nodes: []common.Address{
+			common.HexToAddress("0xEB3B90FD1862B10D14D71881B32D80E530AD394B"),
+			common.HexToAddress("0x01FDCC35858C76C6ECD459DA0174116FB5A4BFF7"),
+			common.HexToAddress("0xA94F5374FCE5EDBC8E2A8697C15331677E6EBF0B"),
+		},
+	}
+	unsigned := list
+	unsigned.Signatures = nil
+	set, err := newRootSet(&unsigned)
+	if err != nil || set == nil {
+		t.Fatalf("newRootSet: %v", err)
+	}
+	list.Hash = set.hash
+
+	chainID := uint64(999)
+	unsigned = list
+	unsigned.Signatures = nil
+	set, err = newRootSet(&unsigned)
+	if err != nil || set == nil {
+		t.Fatalf("newRootSet: %v", err)
+	}
+
+	d1, err := rootListEIP712Digest(chainID, set.timestamp, set.hash, set.rootAddresses)
+	if err != nil {
+		t.Fatalf("digest: %v", err)
+	}
+	d2, err := rootListEIP712Digest(chainID, set.timestamp, set.hash, set.rootAddresses)
+	if err != nil {
+		t.Fatalf("digest: %v", err)
+	}
+	if d1 != d2 {
+		t.Fatalf("expected deterministic EIP-712 digest")
+	}
+
+	custom := common.NewRootListSigningPayloadV1(chainID, list).Hash()
+	if d1 == custom {
+		t.Fatalf("EIP-712 digest must differ from legacy custom canonical digest")
+	}
+}
+
+func TestExclusionListEIP712_DistinctProposalTypes(t *testing.T) {
+	chainID := uint64(1337)
+	hash := common.HexToHash("0x67b6914c8f2d6642eb5a2488b3fd3e6fec57f6f2de6f2c9e1fdbf0ef8e16b3fa")
+	addr := common.HexToAddress("0xA94F5374FCE5EDBC8E2A8697C15331677E6EBF0B")
+	timestamp := uint64(1715072400)
+
+	rootDigest, err := rootListEIP712Digest(chainID, timestamp, hash, []common.Address{addr})
+	if err != nil {
+		t.Fatalf("root digest: %v", err)
+	}
+	exDigest, err := exclusionListEIP712Digest(chainID, timestamp, hash, []common.ExcludedValidator{{Address: addr, Block: 1}})
+	if err != nil {
+		t.Fatalf("exclusion digest: %v", err)
+	}
+	if rootDigest == exDigest {
+		t.Fatalf("root and exclusion EIP-712 digests must not collide")
+	}
+}

--- a/governance/handler_test.go
+++ b/governance/handler_test.go
@@ -720,19 +720,13 @@ func TestSubmitTypedSignedRootList(t *testing.T) {
 		unsigned := list
 		unsigned.Signatures = nil
 
-		payloadHash := common.NewRootListSigningPayloadV1(rm.networkId, unsigned).Hash()
-
 		var key *ecdsa.PrivateKey
 		if signByAlias {
 			key = rm.aliasPrivateKeys[0]
 		} else {
 			key = rm.rootPrivateKeys[0]
 		}
-		signature, err := crypto.Sign(payloadHash.Bytes(), key)
-		if err != nil {
-			t.Fatalf("failed to sign typed root payload: %v", err)
-		}
-		list.Signatures = [][]byte{signature}
+		list.Signatures = [][]byte{signRootListEIP712(t, rm.networkId, list, key)}
 		return list
 	}
 
@@ -743,8 +737,15 @@ func TestSubmitTypedSignedRootList(t *testing.T) {
 		unsigned := list
 		unsigned.Signatures = nil
 
-		payloadHash := common.NewRootListSigningPayloadV1(chainID, unsigned).Hash()
-		signature, err := crypto.Sign(payloadHash.Bytes(), rm.aliasPrivateKeys[0])
+		set, err := newRootSet(&unsigned)
+		if err != nil || set == nil {
+			t.Fatalf("newRootSet: %v", err)
+		}
+		digest, err := rootListEIP712Digest(chainID, set.timestamp, set.hash, set.rootAddresses)
+		if err != nil {
+			t.Fatalf("rootListEIP712Digest: %v", err)
+		}
+		signature, err := crypto.Sign(digest.Bytes(), rm.aliasPrivateKeys[0])
 		if err != nil {
 			t.Fatalf("failed to sign typed root payload: %v", err)
 		}
@@ -758,14 +759,15 @@ func TestSubmitTypedSignedRootList(t *testing.T) {
 		list := randomRootList(t, rm, time.Now().Add(5*time.Minute).Unix(), 10, 0, true)
 		unsigned := list
 		unsigned.Signatures = nil
-		unsigned.Timestamp++
+		tampered := unsigned
+		tampered.Timestamp++
 
-		payloadHash := common.NewRootListSigningPayloadV1(rm.networkId, unsigned).Hash()
-		signature, err := crypto.Sign(payloadHash.Bytes(), rm.aliasPrivateKeys[0])
-		if err != nil {
-			t.Fatalf("failed to sign typed root payload: %v", err)
+		set, err := newRootSet(&list)
+		if err != nil || set == nil {
+			t.Fatalf("newRootSet: %v", err)
 		}
-		list.Signatures = [][]byte{signature}
+		td := rootListEIP712TypedData(rm.networkId, tampered.Timestamp, set.hash, set.rootAddresses)
+		list.Signatures = [][]byte{signRootListEIP712FromTypedData(t, td, rm.aliasPrivateKeys[0])}
 		return list
 	}
 
@@ -776,13 +778,13 @@ func TestSubmitTypedSignedRootList(t *testing.T) {
 		unsigned := list
 		unsigned.Signatures = nil
 
-		payload := common.NewRootListSigningPayloadV1(rm.networkId, unsigned)
-		payload.Metadata.ProposalType = common.GovernanceProposalTypeExclusionList
-		signature, err := crypto.Sign(payload.Hash().Bytes(), rm.aliasPrivateKeys[0])
-		if err != nil {
-			t.Fatalf("failed to sign typed root payload: %v", err)
+		set, err := newRootSet(&unsigned)
+		if err != nil || set == nil {
+			t.Fatalf("newRootSet: %v", err)
 		}
-		list.Signatures = [][]byte{signature}
+		td := rootListEIP712TypedData(rm.networkId, set.timestamp, set.hash, set.rootAddresses)
+		td.Message["proposalType"] = common.GovernanceProposalTypeExclusionList
+		list.Signatures = [][]byte{signRootListEIP712FromTypedData(t, td, rm.aliasPrivateKeys[0])}
 		return list
 	}
 
@@ -872,19 +874,13 @@ func TestSubmitTypedSignedExclusionList(t *testing.T) {
 		unsigned := list
 		unsigned.Signatures = nil
 
-		payloadHash := common.NewExclusionListSigningPayloadV1(rm.networkId, unsigned).Hash()
-
 		var key *ecdsa.PrivateKey
 		if signByAlias {
 			key = rm.aliasPrivateKeys[0]
 		} else {
 			key = rm.rootPrivateKeys[0]
 		}
-		signature, err := crypto.Sign(payloadHash.Bytes(), key)
-		if err != nil {
-			t.Fatalf("failed to sign typed exclusion payload: %v", err)
-		}
-		list.Signatures = [][]byte{signature}
+		list.Signatures = [][]byte{signExclusionListEIP712(t, rm.networkId, list, key)}
 		return list
 	}
 
@@ -895,8 +891,18 @@ func TestSubmitTypedSignedExclusionList(t *testing.T) {
 		unsigned := list
 		unsigned.Signatures = nil
 
-		payloadHash := common.NewExclusionListSigningPayloadV1(chainID, unsigned).Hash()
-		signature, err := crypto.Sign(payloadHash.Bytes(), rm.aliasPrivateKeys[0])
+		set, err := newExclusionSet(&unsigned)
+		if err != nil || set == nil {
+			t.Fatalf("newExclusionSet: %v", err)
+		}
+		source := set.makeList()
+		source.Signatures = nil
+		validators := canonicalExcludedValidatorsForEIP712(source.Validators)
+		digest, err := exclusionListEIP712Digest(chainID, set.timestamp, set.hash, validators)
+		if err != nil {
+			t.Fatalf("exclusionListEIP712Digest: %v", err)
+		}
+		signature, err := crypto.Sign(digest.Bytes(), rm.aliasPrivateKeys[0])
 		if err != nil {
 			t.Fatalf("failed to sign typed exclusion payload: %v", err)
 		}
@@ -910,14 +916,18 @@ func TestSubmitTypedSignedExclusionList(t *testing.T) {
 		list := signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, 1, true, 6000)
 		unsigned := list
 		unsigned.Signatures = nil
-		unsigned.Timestamp++
+		tampered := unsigned
+		tampered.Timestamp++
 
-		payloadHash := common.NewExclusionListSigningPayloadV1(rm.networkId, unsigned).Hash()
-		signature, err := crypto.Sign(payloadHash.Bytes(), rm.aliasPrivateKeys[0])
-		if err != nil {
-			t.Fatalf("failed to sign typed exclusion payload: %v", err)
+		set, err := newExclusionSet(&list)
+		if err != nil || set == nil {
+			t.Fatalf("newExclusionSet: %v", err)
 		}
-		list.Signatures = [][]byte{signature}
+		source := set.makeList()
+		source.Signatures = nil
+		validators := canonicalExcludedValidatorsForEIP712(source.Validators)
+		td := exclusionListEIP712TypedData(rm.networkId, tampered.Timestamp, set.hash, validators)
+		list.Signatures = [][]byte{signExclusionListEIP712FromTypedData(t, td, rm.aliasPrivateKeys[0])}
 		return list
 	}
 
@@ -928,13 +938,16 @@ func TestSubmitTypedSignedExclusionList(t *testing.T) {
 		unsigned := list
 		unsigned.Signatures = nil
 
-		payload := common.NewExclusionListSigningPayloadV1(rm.networkId, unsigned)
-		payload.Metadata.ProposalType = common.GovernanceProposalTypeRootList
-		signature, err := crypto.Sign(payload.Hash().Bytes(), rm.aliasPrivateKeys[0])
-		if err != nil {
-			t.Fatalf("failed to sign typed exclusion payload: %v", err)
+		set, err := newExclusionSet(&unsigned)
+		if err != nil || set == nil {
+			t.Fatalf("newExclusionSet: %v", err)
 		}
-		list.Signatures = [][]byte{signature}
+		source := set.makeList()
+		source.Signatures = nil
+		validators := canonicalExcludedValidatorsForEIP712(source.Validators)
+		td := exclusionListEIP712TypedData(rm.networkId, set.timestamp, set.hash, validators)
+		td.Message["proposalType"] = common.GovernanceProposalTypeRootList
+		list.Signatures = [][]byte{signExclusionListEIP712FromTypedData(t, td, rm.aliasPrivateKeys[0])}
 		return list
 	}
 
@@ -944,15 +957,18 @@ func TestSubmitTypedSignedExclusionList(t *testing.T) {
 		list := signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, 1, true, 6000)
 		unsigned := list
 		unsigned.Signatures = nil
-		unsigned.Validators = append([]common.ExcludedValidator(nil), list.Validators...)
-		unsigned.Validators[0].EndBlock++
+		tampered := append([]common.ExcludedValidator(nil), list.Validators...)
+		tampered[0].EndBlock++
 
-		payloadHash := common.NewExclusionListSigningPayloadV1(rm.networkId, unsigned).Hash()
-		signature, err := crypto.Sign(payloadHash.Bytes(), rm.aliasPrivateKeys[0])
-		if err != nil {
-			t.Fatalf("failed to sign typed exclusion payload: %v", err)
+		set, err := newExclusionSet(&list)
+		if err != nil || set == nil {
+			t.Fatalf("newExclusionSet: %v", err)
 		}
-		list.Signatures = [][]byte{signature}
+		source := set.makeList()
+		source.Signatures = nil
+		validators := canonicalExcludedValidatorsForEIP712(tampered)
+		td := exclusionListEIP712TypedData(rm.networkId, set.timestamp, set.hash, validators)
+		list.Signatures = [][]byte{signExclusionListEIP712FromTypedData(t, td, rm.aliasPrivateKeys[0])}
 		return list
 	}
 
@@ -1042,7 +1058,7 @@ func TestSubmitTypedSignedExclusionList(t *testing.T) {
 }
 
 func TestGovPubSigningPayloadV1(t *testing.T) {
-	t.Run("root list payload matches canonical builder and typed submit", func(t *testing.T) {
+	t.Run("root list payload is EIP-712 and typed submit accepts wallet digest", func(t *testing.T) {
 		rm := newTestRootManager(t, false, true)
 		gov, err := New(rm.RootManager, tmpDirName(t))
 		if err != nil {
@@ -1054,36 +1070,32 @@ func TestGovPubSigningPayloadV1(t *testing.T) {
 		api := NewGovernancePublicAPI(gov)
 
 		list := randomRootList(t, rm, time.Now().Add(5*time.Minute).Unix(), 10, 0, true)
-		unsigned := list
-		unsigned.Signatures = nil
-		set, err := newRootSet(&unsigned)
-		if err != nil {
-			t.Fatalf("newRootSet: %v", err)
-		}
-		want := common.NewRootListSigningPayloadV1(rm.networkId, common.RootList{
-			Timestamp: set.timestamp,
-			Nodes:     set.rootAddresses,
-			Hash:      set.hash,
-		})
 		got, err := api.SigningPayloadRootListV1(list)
 		if err != nil {
 			t.Fatalf("SigningPayloadRootListV1: %v", err)
 		}
-		if !reflect.DeepEqual(got, want) {
-			t.Fatalf("payload mismatch\n got: %+v\nwant: %+v", got, want)
+		if got.PrimaryType != common.GovernanceEIP712RootListTypeName {
+			t.Fatalf("primaryType = %s, want %s", got.PrimaryType, common.GovernanceEIP712RootListTypeName)
+		}
+		if got.Message["proposalType"] != common.GovernanceProposalTypeRootList {
+			t.Fatalf("proposalType = %v", got.Message["proposalType"])
 		}
 
-		sig, err := crypto.Sign(got.Hash().Bytes(), rm.aliasPrivateKeys[0])
+		bundle, err := api.SigningPayloadRootListV1WithDigest(list)
 		if err != nil {
-			t.Fatalf("sign: %v", err)
+			t.Fatalf("SigningPayloadRootListV1WithDigest: %v", err)
 		}
-		list.Signatures = [][]byte{sig}
+		if !reflect.DeepEqual(bundle.TypedData, got) {
+			t.Fatalf("WithDigest typedData mismatch")
+		}
+
+		list.Signatures = [][]byte{signRootListEIP712(t, rm.networkId, list, rm.aliasPrivateKeys[0])}
 		if _, err := api.SubmitTypedSignedRootList(list); err != nil {
-			t.Fatalf("SubmitTypedSignedRootList after payload digest: %v", err)
+			t.Fatalf("SubmitTypedSignedRootList after EIP-712 digest: %v", err)
 		}
 	})
 
-	t.Run("root list WithDigest matches plain payload and digest equals Hash", func(t *testing.T) {
+	t.Run("root list WithDigest equals TypedDataAndHash", func(t *testing.T) {
 		rm := newTestRootManager(t, false, true)
 		gov, err := New(rm.RootManager, tmpDirName(t))
 		if err != nil {
@@ -1094,19 +1106,20 @@ func TestGovPubSigningPayloadV1(t *testing.T) {
 		}
 		api := NewGovernancePublicAPI(gov)
 		list := randomRootList(t, rm, time.Now().Add(5*time.Minute).Unix(), 5, 0, true)
-		plain, err := api.SigningPayloadRootListV1(list)
-		if err != nil {
-			t.Fatalf("SigningPayloadRootListV1: %v", err)
-		}
 		bundle, err := api.SigningPayloadRootListV1WithDigest(list)
 		if err != nil {
 			t.Fatalf("SigningPayloadRootListV1WithDigest: %v", err)
 		}
-		if !reflect.DeepEqual(bundle.Payload, plain) {
-			t.Fatalf("WithDigest payload mismatch: %+v vs %+v", bundle.Payload, plain)
+		td, err := fromPublicEIP712TypedData(bundle.TypedData)
+		if err != nil {
+			t.Fatalf("fromPublicEIP712TypedData: %v", err)
 		}
-		if bundle.Digest != plain.Hash() {
-			t.Fatalf("digest %s want payload.Hash %s", bundle.Digest.Hex(), plain.Hash().Hex())
+		wantDigest, err := eip712Digest(td)
+		if err != nil {
+			t.Fatalf("eip712Digest: %v", err)
+		}
+		if bundle.Digest != wantDigest {
+			t.Fatalf("digest %s want EIP-712 hash %s", bundle.Digest.Hex(), wantDigest.Hex())
 		}
 	})
 
@@ -1134,17 +1147,16 @@ func TestGovPubSigningPayloadV1(t *testing.T) {
 		if err != nil {
 			t.Fatalf("newRootSet: %v", err)
 		}
-		want := common.NewRootListSigningPayloadV1(rm.networkId, common.RootList{
-			Timestamp: set.timestamp,
-			Nodes:     set.rootAddresses,
-			Hash:      set.hash,
-		})
-		got, err := api.SigningPayloadRootListV1(scrambled)
+		wantDigest, err := rootListEIP712Digest(rm.networkId, set.timestamp, set.hash, set.rootAddresses)
 		if err != nil {
-			t.Fatalf("SigningPayloadRootListV1: %v", err)
+			t.Fatalf("rootListEIP712Digest: %v", err)
 		}
-		if !reflect.DeepEqual(got, want) {
-			t.Fatalf("payload mismatch\n got: %+v\nwant: %+v", got, want)
+		bundle, err := api.SigningPayloadRootListV1WithDigest(scrambled)
+		if err != nil {
+			t.Fatalf("SigningPayloadRootListV1WithDigest: %v", err)
+		}
+		if bundle.Digest != wantDigest {
+			t.Fatalf("digest %s want %s", bundle.Digest.Hex(), wantDigest.Hex())
 		}
 	})
 
@@ -1174,17 +1186,21 @@ func TestGovPubSigningPayloadV1(t *testing.T) {
 		}
 		source := set.makeList()
 		source.Signatures = nil
-		want := common.NewExclusionListSigningPayloadV1(rm.networkId, source)
-		got, err := api.SigningPayloadExclusionListV1(scrambled)
+		validators := canonicalExcludedValidatorsForEIP712(source.Validators)
+		wantDigest, err := exclusionListEIP712Digest(rm.networkId, set.timestamp, set.hash, validators)
 		if err != nil {
-			t.Fatalf("SigningPayloadExclusionListV1: %v", err)
+			t.Fatalf("exclusionListEIP712Digest: %v", err)
 		}
-		if !reflect.DeepEqual(got, want) {
-			t.Fatalf("payload mismatch\n got: %+v\nwant: %+v", got, want)
+		bundle, err := api.SigningPayloadExclusionListV1WithDigest(scrambled)
+		if err != nil {
+			t.Fatalf("SigningPayloadExclusionListV1WithDigest: %v", err)
+		}
+		if bundle.Digest != wantDigest {
+			t.Fatalf("digest %s want %s", bundle.Digest.Hex(), wantDigest.Hex())
 		}
 	})
 
-	t.Run("exclusion list payload matches canonical builder and typed submit", func(t *testing.T) {
+	t.Run("exclusion list payload is EIP-712 and typed submit accepts wallet digest", func(t *testing.T) {
 		rm := newTestRootManager(t, false, true)
 		gov, err := New(rm.RootManager, tmpDirName(t))
 		if err != nil {
@@ -1198,32 +1214,21 @@ func TestGovPubSigningPayloadV1(t *testing.T) {
 		list := signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, 1, true, 6000)
 		unsigned := list
 		unsigned.Signatures = nil
-		set, err := newExclusionSet(&unsigned)
-		if err != nil {
-			t.Fatalf("newExclusionSet: %v", err)
-		}
-		source := set.makeList()
-		source.Signatures = nil
-		want := common.NewExclusionListSigningPayloadV1(rm.networkId, source)
 		got, err := api.SigningPayloadExclusionListV1(list)
 		if err != nil {
 			t.Fatalf("SigningPayloadExclusionListV1: %v", err)
 		}
-		if !reflect.DeepEqual(got, want) {
-			t.Fatalf("payload mismatch\n got: %+v\nwant: %+v", got, want)
+		if got.PrimaryType != common.GovernanceEIP712ExclusionListTypeName {
+			t.Fatalf("primaryType = %s, want %s", got.PrimaryType, common.GovernanceEIP712ExclusionListTypeName)
 		}
 
-		sig, err := crypto.Sign(got.Hash().Bytes(), rm.aliasPrivateKeys[0])
-		if err != nil {
-			t.Fatalf("sign: %v", err)
-		}
-		list.Signatures = [][]byte{sig}
+		list.Signatures = [][]byte{signExclusionListEIP712(t, rm.networkId, list, rm.aliasPrivateKeys[0])}
 		if _, err := api.SubmitTypedSignedExclusionList(list); err != nil {
-			t.Fatalf("SubmitTypedSignedExclusionList after payload digest: %v", err)
+			t.Fatalf("SubmitTypedSignedExclusionList after EIP-712 digest: %v", err)
 		}
 	})
 
-	t.Run("exclusion list WithDigest matches plain payload and digest equals Hash", func(t *testing.T) {
+	t.Run("exclusion list WithDigest equals TypedDataAndHash", func(t *testing.T) {
 		rm := newTestRootManager(t, false, true)
 		gov, err := New(rm.RootManager, tmpDirName(t))
 		if err != nil {
@@ -1234,19 +1239,20 @@ func TestGovPubSigningPayloadV1(t *testing.T) {
 		}
 		api := NewGovernancePublicAPI(gov)
 		list := signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, 1, true, 7000)
-		plain, err := api.SigningPayloadExclusionListV1(list)
-		if err != nil {
-			t.Fatalf("SigningPayloadExclusionListV1: %v", err)
-		}
 		bundle, err := api.SigningPayloadExclusionListV1WithDigest(list)
 		if err != nil {
 			t.Fatalf("SigningPayloadExclusionListV1WithDigest: %v", err)
 		}
-		if !reflect.DeepEqual(bundle.Payload, plain) {
-			t.Fatalf("WithDigest payload mismatch: %+v vs %+v", bundle.Payload, plain)
+		td, err := fromPublicEIP712TypedData(bundle.TypedData)
+		if err != nil {
+			t.Fatalf("fromPublicEIP712TypedData: %v", err)
 		}
-		if bundle.Digest != plain.Hash() {
-			t.Fatalf("digest %s want payload.Hash %s", bundle.Digest.Hex(), plain.Hash().Hex())
+		wantDigest, err := eip712Digest(td)
+		if err != nil {
+			t.Fatalf("eip712Digest: %v", err)
+		}
+		if bundle.Digest != wantDigest {
+			t.Fatalf("digest %s want EIP-712 hash %s", bundle.Digest.Hex(), wantDigest.Hex())
 		}
 	})
 

--- a/governance/handler_test.go
+++ b/governance/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"math/big"
+	"strings"
 	rand2 "math/rand"
 	"os"
 	"reflect"
@@ -789,9 +790,10 @@ func TestSubmitTypedSignedRootList(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		list    func(t *testing.T, rm *TestRootManager) common.RootList
-		wantErr bool
+		name          string
+		list          func(t *testing.T, rm *TestRootManager) common.RootList
+		wantErr       bool
+		wantErrSubstr string
 	}{
 		{
 			name: "valid typed signature from active alias is accepted without quorum merge",
@@ -804,7 +806,8 @@ func TestSubmitTypedSignedRootList(t *testing.T) {
 			list: func(t *testing.T, rm *TestRootManager) common.RootList {
 				return makeTypedRootList(t, rm, false)
 			},
-			wantErr: true,
+			wantErr:      true,
+			wantErrSubstr: errTypedMustUseAliasPrefix,
 		},
 		{
 			name: "typed signature with wrong chain id is rejected",
@@ -845,6 +848,9 @@ func TestSubmitTypedSignedRootList(t *testing.T) {
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got hash %s", hash.Hex())
+				}
+				if tt.wantErrSubstr != "" && !strings.Contains(err.Error(), tt.wantErrSubstr) {
+					t.Fatalf("error %q missing %q", err, tt.wantErrSubstr)
 				}
 				if rm.proposed != nil && rm.proposed.hash == list.Hash {
 					t.Fatalf("rejected typed root list changed proposed state: %v", rm.proposed)
@@ -973,9 +979,10 @@ func TestSubmitTypedSignedExclusionList(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		list    func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList
-		wantErr bool
+		name          string
+		list          func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList
+		wantErr       bool
+		wantErrSubstr string
 	}{
 		{
 			name: "valid typed signature from active alias is accepted without quorum merge",
@@ -988,7 +995,8 @@ func TestSubmitTypedSignedExclusionList(t *testing.T) {
 			list: func(t *testing.T, rm *TestRootManager) common.ValidatorExclusionList {
 				return makeTypedExclusionList(t, rm, false)
 			},
-			wantErr: true,
+			wantErr:       true,
+			wantErrSubstr: errTypedMustUseAliasPrefix,
 		},
 		{
 			name: "typed signature with wrong chain id is rejected",
@@ -1036,6 +1044,9 @@ func TestSubmitTypedSignedExclusionList(t *testing.T) {
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got hash %s", hash.Hex())
+				}
+				if tt.wantErrSubstr != "" && !strings.Contains(err.Error(), tt.wantErrSubstr) {
+					t.Fatalf("error %q missing %q", err, tt.wantErrSubstr)
 				}
 				if rm.proposedExSet != nil && rm.proposedExSet.hash == list.Hash {
 					t.Fatalf("rejected typed exclusion list changed proposed state: %v", rm.proposedExSet)

--- a/governance/proposal_status.go
+++ b/governance/proposal_status.go
@@ -33,8 +33,9 @@ type GovernanceProposalStatus struct {
 	Timestamp      uint64                      `json:"timestamp"`
 	Signers        []common.Address            `json:"signers"`
 	Threshold      GovernanceProposalThreshold `json:"threshold"`
-	NeedsSignature bool                        `json:"needsSignature"`
-	QueriedSigner  common.Address              `json:"queriedSigner"`
+	NeedsSignature           bool           `json:"needsSignature"`
+	QueriedSigner            common.Address `json:"queriedSigner"`
+	RequiredSigningAddress   common.Address `json:"requiredSigningAddress,omitempty"`
 }
 
 func (a *GovernancePublicAPI) GetGovernanceProposalStatus(proposalType string, hash common.Hash, signer common.Address) (GovernanceProposalStatus, error) {
@@ -57,7 +58,7 @@ func (s *RootManager) rootListProposalStatus(hash common.Hash, queriedSigner com
 	defer s.rootLock.Unlock()
 
 	active := s.active
-	if active != nil {
+	if active != nil && s.isAthosReached() {
 		active.aliases = s.getAliasesOfRoots(active.rootAddresses)
 	}
 
@@ -84,7 +85,7 @@ func (s *RootManager) exclusionListProposalStatus(hash common.Hash, queriedSigne
 
 	s.rootLock.Lock()
 	active := s.active
-	if active != nil {
+	if active != nil && s.isAthosReached() {
 		active.aliases = s.getAliasesOfRoots(active.rootAddresses)
 	}
 	s.rootLock.Unlock()
@@ -148,6 +149,7 @@ func buildRootListProposalStatus(active *rootSet, set *rootSet, phase string, qu
 			MeetsThreshold:   meetsThreshold,
 		}
 		status.NeedsSignature = active.needsSignatureFrom(set.signers, queriedSigner)
+		status.RequiredSigningAddress = active.requiredTypedSigningAddress(queriedSigner)
 	}
 
 	return status
@@ -173,6 +175,7 @@ func buildExclusionListProposalStatus(active *rootSet, set *exclusionSet, phase 
 			MeetsThreshold:   meetsThreshold,
 		}
 		status.NeedsSignature = active.needsSignatureFrom(set.signers, queriedSigner)
+		status.RequiredSigningAddress = active.requiredTypedSigningAddress(queriedSigner)
 	}
 
 	return status

--- a/governance/proposal_status_test.go
+++ b/governance/proposal_status_test.go
@@ -89,6 +89,24 @@ func TestGetGovernanceProposalStatus(t *testing.T) {
 		}
 	})
 
+	t.Run("required signing address is alias when root is queried", func(t *testing.T) {
+		rm := newTestRootManager(t, false, true)
+		active := rm.active.copy()
+
+		proposed := randomRootList(t, rm, time.Now().Add(5*time.Minute).Unix(), 5, 0, true)
+		set, err := newRootSet(&proposed)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rootAddr := crypto.PubkeyToAddress(rm.rootPrivateKeys[0].PublicKey)
+		aliasAddr := crypto.PubkeyToAddress(rm.aliasPrivateKeys[0].PublicKey)
+		status := buildRootListProposalStatus(active, set, governanceProposalPhaseProposed, rootAddr)
+		if status.RequiredSigningAddress != aliasAddr {
+			t.Fatalf("required %s got %s", aliasAddr.Hex(), status.RequiredSigningAddress.Hex())
+		}
+	})
+
 	t.Run("alias still needs signature", func(t *testing.T) {
 		rm := newTestRootManager(t, false, true)
 		active := rm.active.copy()

--- a/governance/root_manager.go
+++ b/governance/root_manager.go
@@ -876,7 +876,7 @@ func (s *RootManager) getActiveRootSet(lock bool) *rootSet {
 		defer s.rootLock.Unlock()
 	}
 
-	if s.active != nil {
+	if s.active != nil && s.isAthosReached() {
 		s.active.aliases = s.getAliasesOfRoots(s.active.rootAddresses)
 	}
 
@@ -889,7 +889,7 @@ func (s *RootManager) getDesiredRootSet(lock bool) *rootSet {
 		defer s.rootLock.Unlock()
 	}
 
-	if s.desired != nil {
+	if s.desired != nil && s.isAthosReached() {
 		s.desired.aliases = s.getAliasesOfRoots(s.desired.rootAddresses)
 	}
 
@@ -902,7 +902,7 @@ func (s *RootManager) getProposedRootSet(lock bool) *rootSet {
 		defer s.rootLock.Unlock()
 	}
 
-	if s.proposed != nil {
+	if s.proposed != nil && s.isAthosReached() {
 		s.proposed.aliases = s.getAliasesOfRoots(s.proposed.rootAddresses)
 	}
 

--- a/governance/root_manager_test.go
+++ b/governance/root_manager_test.go
@@ -163,17 +163,18 @@ func newTestRootManagerWithAccounts(t *testing.T, isRootNode, useAliases bool, n
 		}
 	}
 
-	aliases = roots
 	if useAliases {
-		aliases = aliases[:0]
+		aliases = make([]common.Address, len(roots))
 		for i := 0; i < len(roots); i++ {
 			aliasPrivateKey, err := crypto.GenerateKey()
 			if err != nil {
 				t.Fatalf("Failed to generate random private key: %v", err)
 			}
 			aliasKeys = append(aliasKeys, aliasPrivateKey)
-			aliases = append(aliases, crypto.PubkeyToAddress(aliasPrivateKey.PublicKey))
+			aliases[i] = crypto.PubkeyToAddress(aliasPrivateKey.PublicKey)
 		}
+	} else {
+		aliases = append([]common.Address(nil), roots...)
 	}
 
 	accountAliases := make(map[common.Address]common.Address)

--- a/governance/signature_parse.go
+++ b/governance/signature_parse.go
@@ -21,16 +21,7 @@ func verifyRootListSignature(set *rootSet, sig []byte, networkID uint64, typedFi
 		return crypto.PubkeyToAddress(*pubkey), true
 	}
 	tryTyped := func() (common.Address, bool) {
-		payloadHash := common.NewRootListSigningPayloadV1(networkID, common.RootList{
-			Timestamp: set.timestamp,
-			Nodes:     set.rootAddresses,
-			Hash:      set.hash,
-		}).Hash()
-		pubkey, err := crypto.SigToPub(payloadHash.Bytes(), sig)
-		if err != nil {
-			return common.Address{}, false
-		}
-		return crypto.PubkeyToAddress(*pubkey), true
+		return verifyRootListEIP712Signature(networkID, set, sig)
 	}
 
 	if typedFirst {
@@ -58,14 +49,7 @@ func verifyExclusionListSignature(set *exclusionSet, sig []byte, networkID uint6
 		return crypto.PubkeyToAddress(*pubkey), true
 	}
 	tryTyped := func() (common.Address, bool) {
-		unsigned := set.makeList()
-		unsigned.Signatures = nil
-		payloadHash := common.NewExclusionListSigningPayloadV1(networkID, unsigned).Hash()
-		pubkey, err := crypto.SigToPub(payloadHash.Bytes(), sig)
-		if err != nil {
-			return common.Address{}, false
-		}
-		return crypto.PubkeyToAddress(*pubkey), true
+		return verifyExclusionListEIP712Signature(networkID, set, sig)
 	}
 
 	if typedFirst {

--- a/governance/typed_exclusion_list.go
+++ b/governance/typed_exclusion_list.go
@@ -36,8 +36,8 @@ func (s *RootManager) newTypedSignedExclusionSet(list common.ValidatorExclusionL
 			return nil, errInvalidSignature
 		}
 
-		if len(active.knownSigners(map[common.Address][]byte{signer: signature})) == 0 {
-			return nil, errors.New("typed exclusion list contains unknown signer")
+		if err := validateTypedActiveSigner(active, signer, "exclusion list"); err != nil {
+			return nil, err
 		}
 		signers[signer] = signature
 	}

--- a/governance/typed_exclusion_list.go
+++ b/governance/typed_exclusion_list.go
@@ -3,7 +3,6 @@ package governance
 import (
 	"github.com/pkg/errors"
 	"gitlab.com/q-dev/q-client/common"
-	"gitlab.com/q-dev/q-client/crypto"
 )
 
 func (s *RootManager) newTypedSignedExclusionSet(list common.ValidatorExclusionList) (*exclusionSet, error) {
@@ -25,8 +24,6 @@ func (s *RootManager) newTypedSignedExclusionSet(list common.ValidatorExclusionL
 	unsignedList := set.makeList()
 	unsignedList.Signatures = nil
 
-	payloadHash := common.NewExclusionListSigningPayloadV1(s.networkId, unsignedList).Hash()
-
 	active := s.getActiveRootSet(true)
 	if active == nil {
 		return nil, errors.New("active root list is unavailable")
@@ -34,11 +31,10 @@ func (s *RootManager) newTypedSignedExclusionSet(list common.ValidatorExclusionL
 
 	signers := make(map[common.Address][]byte)
 	for _, signature := range list.Signatures {
-		pubkey, err := crypto.SigToPub(payloadHash.Bytes(), signature)
-		if err != nil {
+		signer, ok := verifyExclusionListEIP712Signature(s.networkId, set, signature)
+		if !ok {
 			return nil, errInvalidSignature
 		}
-		signer := crypto.PubkeyToAddress(*pubkey)
 
 		if len(active.knownSigners(map[common.Address][]byte{signer: signature})) == 0 {
 			return nil, errors.New("typed exclusion list contains unknown signer")

--- a/governance/typed_relay_test.go
+++ b/governance/typed_relay_test.go
@@ -92,20 +92,27 @@ func testTypedRootList(t *testing.T, rm *TestRootManager) common.RootList {
 	unsigned := list
 	unsigned.Signatures = nil
 
-	payloadHash := common.NewRootListSigningPayloadV1(rm.networkId, unsigned).Hash()
-
 	root := rm.active.rootAddresses[0]
 	signer := rm.active.aliases[root]
 
 	var signature []byte
-	var err error
 	if len(rm.aliasPrivateKeys) > 0 {
-		signature, err = crypto.Sign(payloadHash.Bytes(), rm.aliasPrivateKeys[0])
+		signature = signRootListEIP712(t, rm.networkId, list, rm.aliasPrivateKeys[0])
 	} else {
-		signature, err = rm.SignHash(accounts.Account{Address: signer}, payloadHash.Bytes())
-	}
-	if err != nil {
-		t.Fatalf("sign typed payload: %v", err)
+		unsigned := list
+		unsigned.Signatures = nil
+		set, err := newRootSet(&unsigned)
+		if err != nil || set == nil {
+			t.Fatalf("newRootSet: %v", err)
+		}
+		digest, err := rootListEIP712Digest(rm.networkId, set.timestamp, set.hash, set.rootAddresses)
+		if err != nil {
+			t.Fatalf("rootListEIP712Digest: %v", err)
+		}
+		signature, err = rm.SignHash(accounts.Account{Address: signer}, digest.Bytes())
+		if err != nil {
+			t.Fatalf("sign typed payload: %v", err)
+		}
 	}
 	list.Signatures = [][]byte{signature}
 	return list

--- a/governance/typed_root_list.go
+++ b/governance/typed_root_list.go
@@ -33,8 +33,8 @@ func (s *RootManager) newTypedSignedRootSet(list common.RootList) (*rootSet, err
 			return nil, errInvalidSignature
 		}
 
-		if len(active.knownSigners(map[common.Address][]byte{signer: signature})) == 0 {
-			return nil, errors.New("typed root list contains unknown signer")
+		if err := validateTypedActiveSigner(active, signer, "root list"); err != nil {
+			return nil, err
 		}
 		signers[signer] = signature
 	}

--- a/governance/typed_root_list.go
+++ b/governance/typed_root_list.go
@@ -3,7 +3,6 @@ package governance
 import (
 	"github.com/pkg/errors"
 	"gitlab.com/q-dev/q-client/common"
-	"gitlab.com/q-dev/q-client/crypto"
 )
 
 func (s *RootManager) newTypedSignedRootSet(list common.RootList) (*rootSet, error) {
@@ -22,12 +21,6 @@ func (s *RootManager) newTypedSignedRootSet(list common.RootList) (*rootSet, err
 		return nil, errors.New("invalid typed root list")
 	}
 
-	payloadHash := common.NewRootListSigningPayloadV1(s.networkId, common.RootList{
-		Timestamp: set.timestamp,
-		Nodes:     set.rootAddresses,
-		Hash:      set.hash,
-	}).Hash()
-
 	active := s.getActiveRootSet(true)
 	if active == nil {
 		return nil, errors.New("active root list is unavailable")
@@ -35,11 +28,10 @@ func (s *RootManager) newTypedSignedRootSet(list common.RootList) (*rootSet, err
 
 	signers := make(map[common.Address][]byte)
 	for _, signature := range list.Signatures {
-		pubkey, err := crypto.SigToPub(payloadHash.Bytes(), signature)
-		if err != nil {
+		signer, ok := verifyRootListEIP712Signature(s.networkId, set, signature)
+		if !ok {
 			return nil, errInvalidSignature
 		}
-		signer := crypto.PubkeyToAddress(*pubkey)
 
 		if len(active.knownSigners(map[common.Address][]byte{signer: signature})) == 0 {
 			return nil, errors.New("typed root list contains unknown signer")

--- a/governance/typed_signer.go
+++ b/governance/typed_signer.go
@@ -1,0 +1,41 @@
+package governance
+
+import (
+	"fmt"
+
+	"gitlab.com/q-dev/q-client/common"
+)
+
+// errTypedMustUseAliasPrefix is the stable substring returned when a typed signature
+// was recovered from a root main key but the active set requires the alias address.
+const errTypedMustUseAliasPrefix = "signer must use alias"
+
+func (s *rootSet) requiredTypedSigningAddress(queried common.Address) common.Address {
+	if s == nil || queried == (common.Address{}) {
+		return common.Address{}
+	}
+	for root, alias := range s.aliases {
+		if queried == root || queried == alias {
+			if root != alias {
+				return alias
+			}
+			return root
+		}
+	}
+	return common.Address{}
+}
+
+func validateTypedActiveSigner(active *rootSet, signer common.Address, proposalLabel string) error {
+	if active == nil {
+		return fmt.Errorf("active root list is unavailable")
+	}
+	if len(active.knownSigners(map[common.Address][]byte{signer: nil})) > 0 {
+		return nil
+	}
+	for root, alias := range active.aliases {
+		if root != alias && signer == root {
+			return fmt.Errorf("typed %s: %s %s, not root %s", proposalLabel, errTypedMustUseAliasPrefix, alias.Hex(), root.Hex())
+		}
+	}
+	return fmt.Errorf("typed %s contains unknown signer", proposalLabel)
+}

--- a/governance/typed_signer_test.go
+++ b/governance/typed_signer_test.go
@@ -1,0 +1,49 @@
+package governance
+
+import (
+	"strings"
+	"testing"
+
+	"gitlab.com/q-dev/q-client/crypto"
+)
+
+func TestValidateTypedActiveSignerAliasRequired(t *testing.T) {
+	rm := newTestRootManager(t, false, true)
+	active := rm.active.copy()
+
+	rootAddr := crypto.PubkeyToAddress(rm.rootPrivateKeys[0].PublicKey)
+	aliasAddr := crypto.PubkeyToAddress(rm.aliasPrivateKeys[0].PublicKey)
+
+	err := validateTypedActiveSigner(active, rootAddr, "root list")
+	if err == nil {
+		t.Fatal("expected error for root key when alias is required")
+	}
+	if !strings.Contains(err.Error(), errTypedMustUseAliasPrefix) {
+		t.Fatalf("error %q missing %q", err, errTypedMustUseAliasPrefix)
+	}
+	if !strings.Contains(err.Error(), aliasAddr.Hex()) {
+		t.Fatalf("error %q missing alias %s", err, aliasAddr.Hex())
+	}
+	if !strings.Contains(err.Error(), rootAddr.Hex()) {
+		t.Fatalf("error %q missing root %s", err, rootAddr.Hex())
+	}
+
+	if err := validateTypedActiveSigner(active, aliasAddr, "exclusion list"); err != nil {
+		t.Fatalf("alias signer should be accepted: %v", err)
+	}
+}
+
+func TestRequiredTypedSigningAddress(t *testing.T) {
+	rm := newTestRootManager(t, false, true)
+	active := rm.active.copy()
+
+	rootAddr := crypto.PubkeyToAddress(rm.rootPrivateKeys[0].PublicKey)
+	aliasAddr := crypto.PubkeyToAddress(rm.aliasPrivateKeys[0].PublicKey)
+
+	if got := active.requiredTypedSigningAddress(rootAddr); got != aliasAddr {
+		t.Fatalf("root queried: got %s want alias %s", got.Hex(), aliasAddr.Hex())
+	}
+	if got := active.requiredTypedSigningAddress(aliasAddr); got != aliasAddr {
+		t.Fatalf("alias queried: got %s want %s", got.Hex(), aliasAddr.Hex())
+	}
+}

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -941,7 +941,12 @@ const GovPublicJs = `
 web3._extend({
 	property: 'govPub',
 	methods: [
-        new web3._extend.Method({
+		new web3._extend.Method({
+			name: 'l0GovernanceCapabilities',
+			call: 'govPub_l0GovernanceCapabilities',
+			params: 0
+		}),
+		new web3._extend.Method({
 			name: 'activeRootList',
 			call: 'govPub_activeRootList',
 			params: 0

--- a/internal/web3ext/web3ext_test.go
+++ b/internal/web3ext/web3ext_test.go
@@ -7,6 +7,8 @@ import (
 
 func TestGovernanceSubmissionWeb3Extensions(t *testing.T) {
 	for _, expected := range []string{
+		"name: 'l0GovernanceCapabilities'",
+		"call: 'govPub_l0GovernanceCapabilities'",
 		"name: 'submitSignedRootList'",
 		"call: 'govPub_submitSignedRootList'",
 		"name: 'signingPayloadRootListV1'",


### PR DESCRIPTION
## Summary

Epic B follow-up for external L0 governance dapp integration on `external-l0`:

- **EIP-712 typed signing** (#32): `govPub_signingPayload*` returns wallet-ready typed data; typed submit/verify uses `TypedDataAndHash` + `SigToPub` (domain `QGOV-L0-Governance` v1, zero verifying contract).
- **Alias UX** (#26): typed submit returns a stable `signer must use alias …, not root …` error; `getGovernanceProposalStatus` exposes `requiredSigningAddress`.
- **Capability discovery** (#24): new `govPub_l0GovernanceCapabilities` advertises submission/signing/status helpers, `externalSubmissionEnabled`, alias policy, and `qgovTypedRelayVersion` separately from raw p2p negotiation.

Also fixes test alias slice overlap in `newTestRootManager` and preserves pre-Athos alias maps on `getActiveRootSet`.

## Commits

- `6f81926fe` — EIP-712 for typed L0 governance signing and verification
- `8460e29a5` — Explicit errors when typed sig uses root key instead of alias
- `354b799c2` — `govPub_l0GovernanceCapabilities` for dapp feature discovery

## Test plan

- [ ] `go test ./governance -run "TestL0GovernanceCapabilities|TestValidateTypedActiveSigner|TestSubmitTypedSigned|TestRootListEIP712"`
- [ ] `go test ./internal/web3ext -run TestGovernanceSubmissionWeb3Extensions`
- [ ] Dapp probes `govPub_l0GovernanceCapabilities` with `DisablePublicSubmission` on/off
- [ ] Wallet `eth_signTypedData_v4` on signing-payload RPCs matches typed submit acceptance

Closes #24, #26. Related: #32 (EIP-712). Follow-up to #29.
