### PR TITLE
governance: hex JSON signatures and wallet v normalization (#35, #36)

### DIFF
--- a/common/governance.go
+++ b/common/governance.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+
+	"gitlab.com/q-dev/q-client/common/hexutil"
 )
 
 // RootList.
@@ -13,7 +15,20 @@ type RootList struct {
 	Nodes     []Address `json:"nodes"`
 	Hash      Hash      `json:"hash"`
 
-	Signatures [][]byte `json:"signatures"`
+	// Signatures use 0x hex in JSON-RPC (hexutil.Bytes); not base64.
+	Signatures []hexutil.Bytes `json:"signatures"`
+}
+
+// HexSignaturesFromBytes converts raw signature slices for JSON-RPC list payloads.
+func HexSignaturesFromBytes(sigs [][]byte) []hexutil.Bytes {
+	if len(sigs) == 0 {
+		return nil
+	}
+	out := make([]hexutil.Bytes, len(sigs))
+	for i, b := range sigs {
+		out[i] = hexutil.Bytes(b)
+	}
+	return out
 }
 
 // ValidatorExclusionList.
@@ -22,7 +37,8 @@ type ValidatorExclusionList struct {
 	Validators []ExcludedValidator `json:"validators"`
 	Hash       Hash                `json:"hash"`
 
-	Signatures [][]byte `json:"signatures"`
+	// Signatures use 0x hex in JSON-RPC (hexutil.Bytes); not base64.
+	Signatures []hexutil.Bytes `json:"signatures"`
 }
 
 func (el ValidatorExclusionList) IsEmpty() bool {

--- a/common/governance_json_test.go
+++ b/common/governance_json_test.go
@@ -1,0 +1,58 @@
+package common
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gitlab.com/q-dev/q-client/common/hexutil"
+)
+
+func TestRootListSignaturesJSON_hexOnly(t *testing.T) {
+	sigHex := hexutil.Encode(make([]byte, 65))
+	payload := `{
+		"timestamp": 1715072400,
+		"nodes": ["0xEB3B90FD1862B10D14D71881B32D80E530AD394B"],
+		"hash": "0x0000000000000000000000000000000000000000000000000000000000000001",
+		"signatures": ["` + sigHex + `"]
+	}`
+
+	var list RootList
+	if err := json.Unmarshal([]byte(payload), &list); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(list.Signatures) != 1 {
+		t.Fatalf("signatures len %d", len(list.Signatures))
+	}
+	if len(list.Signatures[0]) != 65 {
+		t.Fatalf("signature bytes len %d", len(list.Signatures[0]))
+	}
+
+	out, err := json.Marshal(list)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !json.Valid(out) {
+		t.Fatalf("invalid json: %s", out)
+	}
+	var round RootList
+	if err := json.Unmarshal(out, &round); err != nil {
+		t.Fatalf("round-trip: %v", err)
+	}
+	if hexutil.Encode(round.Signatures[0]) != hexutil.Encode(list.Signatures[0]) {
+		t.Fatalf("signature round-trip mismatch")
+	}
+}
+
+func TestRootListSignaturesJSON_rejectsBase64(t *testing.T) {
+	const payload = `{
+		"timestamp": 1,
+		"nodes": [],
+		"hash": "0x0000000000000000000000000000000000000000000000000000000000000001",
+		"signatures": ["AQID"]
+	}`
+
+	var list RootList
+	if err := json.Unmarshal([]byte(payload), &list); err == nil {
+		t.Fatalf("expected base64 signature to fail, got %d signatures", len(list.Signatures))
+	}
+}

--- a/docs/governance/l0-governance-dapp-concept.md
+++ b/docs/governance/l0-governance-dapp-concept.md
@@ -305,6 +305,20 @@ These methods should be limited to signed payload ingestion, canonical signing p
 
 The dapp should probe the RPC endpoint configured for the connected wallet before enabling signing or submission controls. If the node does not expose the required L0 governance capabilities, the dapp should keep monitoring/read-only views usable, disable action controls, and explain that the selected RPC endpoint does not yet support external L0 governance signing/submission.
 
+### govPub JSON wire format for list signatures
+
+For `govPub_submitSignedRootList`, `govPub_submitTypedSignedRootList`, `govPub_submitSignedExclusionList`, and `govPub_submitTypedSignedExclusionList`, each element of `signatures` must be a **`0x`-prefixed hex string** (65 bytes for a standard ECDSA signature), consistent with `hash` and `address` fields elsewhere in JSON-RPC. **Base64 is not accepted** for `signatures` on these payloads.
+
+Example (typed root list submit):
+
+```json
+"signatures": ["0x<r><s><v>"]
+```
+
+Pass the value returned by `eth_signTypedData_v4` / wallet `signTypedData` **without** re-encoding the recovery byte: q-client normalizes Yellow Paper `v` (`27` / `28`) to the internal `0` / `1` form before verification.
+
+List responses over JSON-RPC marshal `signatures` the same way (`0x` hex). **p2p / RLP** list messages are unchanged.
+
 ### 4. Existing `qgov` p2p propagation
 
 The existing `RootListMsg` / `ExclusionListMsg` / handshake payloads remain the **canonical carrier for raw ECDSA signatures** over the deterministic list hash (`list.Hash`), because that is what all deployed clients verify today (`governance/root_list.go`, `governance/exclusion_set.go`).

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -27,6 +27,7 @@ import (
 
 	ethereum "gitlab.com/q-dev/q-client"
 	"gitlab.com/q-dev/q-client/common"
+	"gitlab.com/q-dev/q-client/common/hexutil"
 	"gitlab.com/q-dev/q-client/consensus/ethash"
 	"gitlab.com/q-dev/q-client/core"
 	"gitlab.com/q-dev/q-client/core/types"
@@ -207,7 +208,7 @@ func TestGovernanceSubmissionWrappers(t *testing.T) {
 		Timestamp:  1,
 		Nodes:      []common.Address{common.HexToAddress("0x1")},
 		Hash:       common.HexToHash("0x1234"),
-		Signatures: [][]byte{{1, 2, 3}},
+		Signatures: []hexutil.Bytes{{1, 2, 3}},
 	}
 	rootHash, err := client.SubmitSignedRootList(context.Background(), rootList)
 	if err != nil {
@@ -221,7 +222,7 @@ func TestGovernanceSubmissionWrappers(t *testing.T) {
 		Timestamp:  2,
 		Validators: []common.ExcludedValidator{{Address: common.HexToAddress("0x2"), Block: 10, EndBlock: 20}},
 		Hash:       common.HexToHash("0x5678"),
-		Signatures: [][]byte{{4, 5, 6}},
+		Signatures: []hexutil.Bytes{{4, 5, 6}},
 	}
 	exclusionHash, err := client.SubmitSignedExclusionList(context.Background(), exclusionList)
 	if err != nil {

--- a/governance/eip712.go
+++ b/governance/eip712.go
@@ -166,7 +166,7 @@ func verifyRootListEIP712Signature(chainID uint64, set *rootSet, sig []byte) (co
 	if err != nil {
 		return common.Address{}, false
 	}
-	pubkey, err := crypto.SigToPub(digest.Bytes(), sig)
+	pubkey, err := crypto.SigToPub(digest.Bytes(), normalizeECDSASignatureV(sig))
 	if err != nil {
 		return common.Address{}, false
 	}
@@ -185,7 +185,7 @@ func verifyExclusionListEIP712Signature(chainID uint64, set *exclusionSet, sig [
 	if err != nil {
 		return common.Address{}, false
 	}
-	pubkey, err := crypto.SigToPub(digest.Bytes(), sig)
+	pubkey, err := crypto.SigToPub(digest.Bytes(), normalizeECDSASignatureV(sig))
 	if err != nil {
 		return common.Address{}, false
 	}

--- a/governance/exclusion_set.go
+++ b/governance/exclusion_set.go
@@ -186,7 +186,7 @@ func (s *exclusionSet) makeList() common.ValidatorExclusionList {
 	return common.ValidatorExclusionList{
 		Timestamp:  s.timestamp,
 		Hash:       s.hash,
-		Signatures: signatures,
+		Signatures: common.HexSignaturesFromBytes(signatures),
 		Validators: validators,
 	}
 }

--- a/governance/exclusion_set_test.go
+++ b/governance/exclusion_set_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"gitlab.com/q-dev/q-client/common"
+	"gitlab.com/q-dev/q-client/common/hexutil"
 )
 
 var (
@@ -155,7 +156,7 @@ var (
 				Block:   1000,
 			},
 		},
-		Signatures: [][]byte{[]byte("0x6662d75a2ddb2c63342dcec4ae307dca29adf5aefd5b06a4586a4541afddcdf4")},
+		Signatures: []hexutil.Bytes{hexutil.MustDecode("0x6662d75a2ddb2c63342dcec4ae307dca29adf5aefd5b06a4586a4541afddcdf4")},
 	}
 )
 

--- a/governance/handler_json_test.go
+++ b/governance/handler_json_test.go
@@ -1,0 +1,93 @@
+package governance
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"gitlab.com/q-dev/q-client/common"
+	"gitlab.com/q-dev/q-client/common/hexutil"
+	"gitlab.com/q-dev/q-client/crypto"
+)
+
+func TestSubmitTypedSignedRootList_hexJSONWire(t *testing.T) {
+	rm := newTestRootManager(t, false, true)
+	gov, err := New(rm.RootManager, tmpDirName(t))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := gov.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	list := randomRootList(t, rm, time.Now().Add(5*time.Minute).Unix(), 10, 0, true)
+	unsigned := list
+	unsigned.Signatures = nil
+	sig := signRootListEIP712(t, rm.networkId, list, rm.aliasPrivateKeys[0])
+	list.Signatures = common.HexSignaturesFromBytes([][]byte{sig})
+
+	raw, err := json.Marshal(list)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !json.Valid(raw) {
+		t.Fatalf("invalid json")
+	}
+
+	var decoded common.RootList
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(decoded.Signatures) != 1 {
+		t.Fatalf("signatures len %d", len(decoded.Signatures))
+	}
+
+	hash, err := NewGovernancePublicAPI(gov).SubmitTypedSignedRootList(decoded)
+	if err != nil {
+		t.Fatalf("SubmitTypedSignedRootList: %v", err)
+	}
+	if hash != list.Hash {
+		t.Fatalf("hash %s want %s", hash.Hex(), list.Hash.Hex())
+	}
+}
+
+func TestSubmitTypedSignedRootList_walletRecoveryByte(t *testing.T) {
+	rm := newTestRootManager(t, false, true)
+	gov, err := New(rm.RootManager, tmpDirName(t))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := gov.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	list := randomRootList(t, rm, time.Now().Add(5*time.Minute).Unix(), 10, 0, true)
+	sig := signRootListEIP712(t, rm.networkId, list, rm.aliasPrivateKeys[0])
+	walletSig := append([]byte(nil), sig...)
+	walletSig[crypto.RecoveryIDOffset] += 27
+	list.Signatures = common.HexSignaturesFromBytes([][]byte{walletSig})
+
+	if _, err := NewGovernancePublicAPI(gov).SubmitTypedSignedRootList(list); err != nil {
+		t.Fatalf("SubmitTypedSignedRootList with v+27: %v", err)
+	}
+}
+
+func TestRootListJSON_signatureMarshalsAsHex(t *testing.T) {
+	sig := hexutil.Bytes(make([]byte, 65))
+	raw, err := json.Marshal(common.RootList{Signatures: []hexutil.Bytes{sig}})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !json.Valid(raw) {
+		t.Fatal("invalid json")
+	}
+	var probe struct {
+		Signatures []string `json:"signatures"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		t.Fatalf("unmarshal probe: %v", err)
+	}
+	if len(probe.Signatures) != 1 || len(probe.Signatures[0]) < 4 || probe.Signatures[0][:2] != "0x" {
+		t.Fatalf("expected 0x hex signature, got %q", probe.Signatures)
+	}
+}

--- a/governance/handler_test.go
+++ b/governance/handler_test.go
@@ -18,6 +18,7 @@ import (
 
 	"gitlab.com/q-dev/q-client/accounts"
 	"gitlab.com/q-dev/q-client/common"
+	"gitlab.com/q-dev/q-client/common/hexutil"
 	"gitlab.com/q-dev/q-client/crypto"
 	"gitlab.com/q-dev/q-client/log"
 	"gitlab.com/q-dev/q-client/p2p"
@@ -368,7 +369,7 @@ func TestImportRootListDoesNotRequireLocalSigning(t *testing.T) {
 		t.Fatalf("failed to sign root list: %v", err)
 	}
 	list.Hash = set.hash
-	list.Signatures = [][]byte{signature}
+	list.Signatures = common.HexSignaturesFromBytes([][]byte{signature})
 
 	if err := gov.handler.importRootList(&list); err != nil {
 		t.Fatalf("importRootList returned error: %v", err)
@@ -727,7 +728,7 @@ func TestSubmitTypedSignedRootList(t *testing.T) {
 		} else {
 			key = rm.rootPrivateKeys[0]
 		}
-		list.Signatures = [][]byte{signRootListEIP712(t, rm.networkId, list, key)}
+		list.Signatures = common.HexSignaturesFromBytes([][]byte{signRootListEIP712(t, rm.networkId, list, key)})
 		return list
 	}
 
@@ -750,7 +751,7 @@ func TestSubmitTypedSignedRootList(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to sign typed root payload: %v", err)
 		}
-		list.Signatures = [][]byte{signature}
+		list.Signatures = common.HexSignaturesFromBytes([][]byte{signature})
 		return list
 	}
 
@@ -768,7 +769,7 @@ func TestSubmitTypedSignedRootList(t *testing.T) {
 			t.Fatalf("newRootSet: %v", err)
 		}
 		td := rootListEIP712TypedData(rm.networkId, tampered.Timestamp, set.hash, set.rootAddresses)
-		list.Signatures = [][]byte{signRootListEIP712FromTypedData(t, td, rm.aliasPrivateKeys[0])}
+		list.Signatures = common.HexSignaturesFromBytes([][]byte{signRootListEIP712FromTypedData(t, td, rm.aliasPrivateKeys[0])})
 		return list
 	}
 
@@ -785,7 +786,7 @@ func TestSubmitTypedSignedRootList(t *testing.T) {
 		}
 		td := rootListEIP712TypedData(rm.networkId, set.timestamp, set.hash, set.rootAddresses)
 		td.Message["proposalType"] = common.GovernanceProposalTypeExclusionList
-		list.Signatures = [][]byte{signRootListEIP712FromTypedData(t, td, rm.aliasPrivateKeys[0])}
+		list.Signatures = common.HexSignaturesFromBytes([][]byte{signRootListEIP712FromTypedData(t, td, rm.aliasPrivateKeys[0])})
 		return list
 	}
 
@@ -886,7 +887,7 @@ func TestSubmitTypedSignedExclusionList(t *testing.T) {
 		} else {
 			key = rm.rootPrivateKeys[0]
 		}
-		list.Signatures = [][]byte{signExclusionListEIP712(t, rm.networkId, list, key)}
+		list.Signatures = common.HexSignaturesFromBytes([][]byte{signExclusionListEIP712(t, rm.networkId, list, key)})
 		return list
 	}
 
@@ -912,7 +913,7 @@ func TestSubmitTypedSignedExclusionList(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to sign typed exclusion payload: %v", err)
 		}
-		list.Signatures = [][]byte{signature}
+		list.Signatures = common.HexSignaturesFromBytes([][]byte{signature})
 		return list
 	}
 
@@ -933,7 +934,7 @@ func TestSubmitTypedSignedExclusionList(t *testing.T) {
 		source.Signatures = nil
 		validators := canonicalExcludedValidatorsForEIP712(source.Validators)
 		td := exclusionListEIP712TypedData(rm.networkId, tampered.Timestamp, set.hash, validators)
-		list.Signatures = [][]byte{signExclusionListEIP712FromTypedData(t, td, rm.aliasPrivateKeys[0])}
+		list.Signatures = common.HexSignaturesFromBytes([][]byte{signExclusionListEIP712FromTypedData(t, td, rm.aliasPrivateKeys[0])})
 		return list
 	}
 
@@ -953,7 +954,7 @@ func TestSubmitTypedSignedExclusionList(t *testing.T) {
 		validators := canonicalExcludedValidatorsForEIP712(source.Validators)
 		td := exclusionListEIP712TypedData(rm.networkId, set.timestamp, set.hash, validators)
 		td.Message["proposalType"] = common.GovernanceProposalTypeRootList
-		list.Signatures = [][]byte{signExclusionListEIP712FromTypedData(t, td, rm.aliasPrivateKeys[0])}
+		list.Signatures = common.HexSignaturesFromBytes([][]byte{signExclusionListEIP712FromTypedData(t, td, rm.aliasPrivateKeys[0])})
 		return list
 	}
 
@@ -974,7 +975,7 @@ func TestSubmitTypedSignedExclusionList(t *testing.T) {
 		source.Signatures = nil
 		validators := canonicalExcludedValidatorsForEIP712(tampered)
 		td := exclusionListEIP712TypedData(rm.networkId, set.timestamp, set.hash, validators)
-		list.Signatures = [][]byte{signExclusionListEIP712FromTypedData(t, td, rm.aliasPrivateKeys[0])}
+		list.Signatures = common.HexSignaturesFromBytes([][]byte{signExclusionListEIP712FromTypedData(t, td, rm.aliasPrivateKeys[0])})
 		return list
 	}
 
@@ -1100,7 +1101,7 @@ func TestGovPubSigningPayloadV1(t *testing.T) {
 			t.Fatalf("WithDigest typedData mismatch")
 		}
 
-		list.Signatures = [][]byte{signRootListEIP712(t, rm.networkId, list, rm.aliasPrivateKeys[0])}
+		list.Signatures = common.HexSignaturesFromBytes([][]byte{signRootListEIP712(t, rm.networkId, list, rm.aliasPrivateKeys[0])})
 		if _, err := api.SubmitTypedSignedRootList(list); err != nil {
 			t.Fatalf("SubmitTypedSignedRootList after EIP-712 digest: %v", err)
 		}
@@ -1233,7 +1234,7 @@ func TestGovPubSigningPayloadV1(t *testing.T) {
 			t.Fatalf("primaryType = %s, want %s", got.PrimaryType, common.GovernanceEIP712ExclusionListTypeName)
 		}
 
-		list.Signatures = [][]byte{signExclusionListEIP712(t, rm.networkId, list, rm.aliasPrivateKeys[0])}
+		list.Signatures = common.HexSignaturesFromBytes([][]byte{signExclusionListEIP712(t, rm.networkId, list, rm.aliasPrivateKeys[0])})
 		if _, err := api.SubmitTypedSignedExclusionList(list); err != nil {
 			t.Fatalf("SubmitTypedSignedExclusionList after EIP-712 digest: %v", err)
 		}
@@ -2418,7 +2419,7 @@ func randomRootList(t *testing.T, rm *TestRootManager, timestamp int64, nodesCou
 	rootList := common.RootList{
 		Timestamp:  uint64(timestamp),
 		Nodes:      make([]common.Address, 0, nodesCount),
-		Signatures: make([][]byte, 0, signersCount),
+		Signatures: make([]hexutil.Bytes, 0, signersCount),
 	}
 	for i := 0; i < nodesCount; i++ {
 		rootList.Nodes = append(rootList.Nodes, common.BytesToAddress(randBytes(common.AddressLength)))
@@ -2455,7 +2456,7 @@ func randomRootList(t *testing.T, rm *TestRootManager, timestamp int64, nodesCou
 		if err != nil {
 			t.Error(errors.Wrap(err, "failed to sign hash"))
 		}
-		rootList.Signatures = append(rootList.Signatures, sig)
+		rootList.Signatures = append(rootList.Signatures, hexutil.Bytes(sig))
 	}
 
 	return rootList
@@ -2465,7 +2466,7 @@ func randomExclusionList(t *testing.T, rm *TestRootManager, timestamp uint64, va
 	exclusionList := common.ValidatorExclusionList{
 		Timestamp:  timestamp,
 		Validators: make([]common.ExcludedValidator, 0, validatorsCount),
-		Signatures: make([][]byte, 0, signersCount),
+		Signatures: make([]hexutil.Bytes, 0, signersCount),
 	}
 	for i := 0; i < validatorsCount; i++ {
 		exclusionList.Validators = append(exclusionList.Validators, common.ExcludedValidator{
@@ -2503,7 +2504,7 @@ func randomExclusionList(t *testing.T, rm *TestRootManager, timestamp uint64, va
 		if err != nil {
 			t.Error(errors.Wrap(err, "failed to sign hash"))
 		}
-		exclusionList.Signatures = append(exclusionList.Signatures, sig)
+		exclusionList.Signatures = append(exclusionList.Signatures, hexutil.Bytes(sig))
 	}
 
 	return exclusionList
@@ -2513,7 +2514,7 @@ func signedExclusionList(t *testing.T, rm *TestRootManager, timestamp uint64, va
 	exclusionList := common.ValidatorExclusionList{
 		Timestamp:  timestamp,
 		Validators: make([]common.ExcludedValidator, 0, validatorsCount),
-		Signatures: make([][]byte, 0, signersCount),
+		Signatures: make([]hexutil.Bytes, 0, signersCount),
 	}
 	for i := 0; i < validatorsCount; i++ {
 		block := blockStart + uint64(i)
@@ -2543,7 +2544,7 @@ func signedExclusionList(t *testing.T, rm *TestRootManager, timestamp uint64, va
 			if err != nil {
 				t.Error(errors.Wrap(err, "failed to sign hash"))
 			}
-			exclusionList.Signatures = append(exclusionList.Signatures, signature)
+			exclusionList.Signatures = append(exclusionList.Signatures, hexutil.Bytes(signature))
 		}
 		return exclusionList
 	} else {
@@ -2561,7 +2562,7 @@ func signedExclusionList(t *testing.T, rm *TestRootManager, timestamp uint64, va
 		if err != nil {
 			t.Error(errors.Wrap(err, "failed to sign hash"))
 		}
-		exclusionList.Signatures = append(exclusionList.Signatures, sig)
+		exclusionList.Signatures = append(exclusionList.Signatures, hexutil.Bytes(sig))
 	}
 
 	return exclusionList
@@ -2588,7 +2589,7 @@ func signedActiveExclusionListWithTimestamp(t *testing.T, rm *TestRootManager, t
 		if err != nil {
 			t.Error(errors.Wrap(err, "failed to sign hash"))
 		}
-		list.Signatures = append(list.Signatures, sig)
+		list.Signatures = append(list.Signatures, hexutil.Bytes(sig))
 	}
 	list.Hash = set.hash
 	return list

--- a/governance/root_list.go
+++ b/governance/root_list.go
@@ -280,6 +280,6 @@ func (s *rootSet) makeList() common.RootList {
 		Timestamp:  s.timestamp,
 		Hash:       s.hash,
 		Nodes:      s.rootAddresses,
-		Signatures: s.signatures(),
+		Signatures: common.HexSignaturesFromBytes(s.signatures()),
 	}
 }

--- a/governance/root_list_test.go
+++ b/governance/root_list_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"gitlab.com/q-dev/q-client/common"
+	"gitlab.com/q-dev/q-client/common/hexutil"
 )
 
 func Test_newRootSet(t *testing.T) {
@@ -73,8 +74,8 @@ func Test_newRootSet(t *testing.T) {
 						common.HexToAddress("0x01FDCC35858C76C6ECD459DA0174116FB5A4BFF7"),
 						common.HexToAddress("0xEB3B90FD1862B10D14D71881B32D80E530AD394B"),
 					},
-					Signatures: [][]byte{
-						common.Hex2Bytes("0xf68af076b760d81d3d2a5071817c7def517a0d60f7e5bec5c65daf6e2dcab855"),
+					Signatures: []hexutil.Bytes{
+						hexutil.Bytes(common.Hex2Bytes("0xf68af076b760d81d3d2a5071817c7def517a0d60f7e5bec5c65daf6e2dcab855")),
 					},
 				},
 			},

--- a/governance/root_manager.go
+++ b/governance/root_manager.go
@@ -220,12 +220,24 @@ func (s *RootManager) canResolveAliasesFromChain() bool {
 	return s.reg.AccountAliases(nil) != nil
 }
 
-// refreshActiveAliases updates active.aliases from chain only when Athos is live and alias resolution is available.
+// refreshActiveAliases updates active.aliases from chain when Athos is live and alias
+// resolution is available. Pre-Athos (or when the registry is unavailable) each root
+// address is its own alias (root == alias), which is the correct pre-Athos identity
+// for typed signing. Self-aliases are only seeded if the map is empty; once aliases
+// have been explicitly set (e.g. from chain) they are not overwritten.
 func (s *RootManager) refreshActiveAliases() {
-	if s == nil || s.active == nil || !s.canResolveAliasesFromChain() {
+	if s == nil || s.active == nil {
 		return
 	}
-	s.active.aliases = s.getAliasesOfRoots(s.active.rootAddresses)
+	if s.canResolveAliasesFromChain() {
+		s.active.aliases = s.getAliasesOfRoots(s.active.rootAddresses)
+		return
+	}
+	// Seed self-aliases so typed signing works before Athos activates or registry is
+	// available, but only when the map has not already been populated from the chain.
+	if len(s.active.aliases) == 0 {
+		s.active.aliases = s.getAliasesOfRoots(s.active.rootAddresses)
+	}
 }
 
 func (s *RootManager) updateAliasesOfRootSets() {

--- a/governance/signature_normalize.go
+++ b/governance/signature_normalize.go
@@ -1,0 +1,18 @@
+package governance
+
+import "gitlab.com/q-dev/q-client/crypto"
+
+// normalizeECDSASignatureV returns a copy of sig with Ethereum Yellow Paper v (27/28)
+// converted to the recovery id form (0/1) expected by crypto.SigToPub. Values already
+// in 0/1 are unchanged. Caller-owned slices are not mutated.
+func normalizeECDSASignatureV(sig []byte) []byte {
+	if len(sig) != crypto.SignatureLength {
+		return sig
+	}
+	out := make([]byte, len(sig))
+	copy(out, sig)
+	if out[crypto.RecoveryIDOffset] >= 27 {
+		out[crypto.RecoveryIDOffset] -= 27
+	}
+	return out
+}

--- a/governance/signature_normalize_test.go
+++ b/governance/signature_normalize_test.go
@@ -1,0 +1,81 @@
+package governance
+
+import (
+	"testing"
+
+	"gitlab.com/q-dev/q-client/common"
+	"gitlab.com/q-dev/q-client/crypto"
+)
+
+func TestNormalizeECDSASignatureV_walletV(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+
+	list := common.RootList{
+		Timestamp: 1715072400,
+		Nodes:     []common.Address{common.HexToAddress("0xA94F5374FCE5EDBC8E2A8697C15331677E6EBF0B")},
+	}
+	unsigned := list
+	set, err := newRootSet(&unsigned)
+	if err != nil || set == nil {
+		t.Fatalf("newRootSet: %v", err)
+	}
+	list.Hash = set.hash
+
+	digest, err := rootListEIP712Digest(1337, set.timestamp, set.hash, set.rootAddresses)
+	if err != nil {
+		t.Fatalf("digest: %v", err)
+	}
+	sig, err := crypto.Sign(digest.Bytes(), key)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+
+	addr0, ok0 := verifyRootListEIP712Signature(1337, set, sig)
+	if !ok0 {
+		t.Fatal("expected v=0/1 signature to verify")
+	}
+
+	walletSig := append([]byte(nil), sig...)
+	walletSig[crypto.RecoveryIDOffset] += 27
+
+	addr27, ok27 := verifyRootListEIP712Signature(1337, set, walletSig)
+	if !ok27 {
+		t.Fatal("expected v=27/28 wallet signature to verify after normalization")
+	}
+	if addr27 != addr0 {
+		t.Fatalf("signer mismatch: %s vs %s", addr27.Hex(), addr0.Hex())
+	}
+
+	norm := normalizeECDSASignatureV(walletSig)
+	if norm[crypto.RecoveryIDOffset] != sig[crypto.RecoveryIDOffset] {
+		t.Fatalf("normalized v=%d want %d", norm[crypto.RecoveryIDOffset], sig[crypto.RecoveryIDOffset])
+	}
+}
+
+func TestVerifyRootListSignature_walletV_rawPath(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+
+	list := common.RootList{Timestamp: 1715072401, Nodes: []common.Address{common.HexToAddress("0x01")}}
+	set, err := newRootSet(&list)
+	if err != nil || set == nil {
+		t.Fatalf("newRootSet: %v", err)
+	}
+
+	sig, err := crypto.Sign(set.hash.Bytes(), key)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	walletSig := append([]byte(nil), sig...)
+	walletSig[crypto.RecoveryIDOffset] += 27
+
+	_, ok := verifyRootListSignature(set, walletSig, 0, false)
+	if !ok {
+		t.Fatal("raw dual-verify path should accept wallet v on list hash")
+	}
+}

--- a/governance/signature_parse.go
+++ b/governance/signature_parse.go
@@ -14,7 +14,7 @@ func verifyRootListSignature(set *rootSet, sig []byte, networkID uint64, typedFi
 	}
 
 	tryRaw := func() (common.Address, bool) {
-		pubkey, err := crypto.SigToPub(set.hash.Bytes(), sig)
+		pubkey, err := crypto.SigToPub(set.hash.Bytes(), normalizeECDSASignatureV(sig))
 		if err != nil {
 			return common.Address{}, false
 		}
@@ -42,7 +42,7 @@ func verifyExclusionListSignature(set *exclusionSet, sig []byte, networkID uint6
 	}
 
 	tryRaw := func() (common.Address, bool) {
-		pubkey, err := crypto.SigToPub(set.hash.Bytes(), sig)
+		pubkey, err := crypto.SigToPub(set.hash.Bytes(), normalizeECDSASignatureV(sig))
 		if err != nil {
 			return common.Address{}, false
 		}
@@ -70,6 +70,6 @@ func (s *rootSet) hasRawSignatureFrom(signer common.Address) bool {
 	if !ok {
 		return false
 	}
-	_, err := crypto.SigToPub(s.hash.Bytes(), sig)
+	_, err := crypto.SigToPub(s.hash.Bytes(), normalizeECDSASignatureV(sig))
 	return err == nil
 }

--- a/governance/typed_relay.go
+++ b/governance/typed_relay.go
@@ -278,7 +278,7 @@ func (s *exclusionSet) hasRawSignatureFrom(signer common.Address) bool {
 	if !ok {
 		return false
 	}
-	_, err := crypto.SigToPub(s.hash.Bytes(), sig)
+	_, err := crypto.SigToPub(s.hash.Bytes(), normalizeECDSASignatureV(sig))
 	return err == nil
 }
 
@@ -289,7 +289,7 @@ func (h *handler) mintAndImportRawRootSignature(proposal *rootSet, signer common
 	}
 
 	list := proposal.makeList()
-	list.Signatures = [][]byte{sig}
+	list.Signatures = common.HexSignaturesFromBytes([][]byte{sig})
 	return h.importRootListFrom("", &list, false)
 }
 
@@ -300,6 +300,6 @@ func (h *handler) mintAndImportRawExclusionSignature(proposal *exclusionSet, sig
 	}
 
 	list := proposal.makeList()
-	list.Signatures = [][]byte{sig}
+	list.Signatures = common.HexSignaturesFromBytes([][]byte{sig})
 	return h.importExclusionListFrom("", &list, false)
 }

--- a/governance/typed_relay_test.go
+++ b/governance/typed_relay_test.go
@@ -114,6 +114,6 @@ func testTypedRootList(t *testing.T, rm *TestRootManager) common.RootList {
 			t.Fatalf("sign typed payload: %v", err)
 		}
 	}
-	list.Signatures = [][]byte{signature}
+	list.Signatures = common.HexSignaturesFromBytes([][]byte{signature})
 	return list
 }


### PR DESCRIPTION
Accept 0x-prefixed hex for signatures[] on govPub list JSON (hexutil.Bytes; no base64). Normalize EIP-712 and dual-verify recovery bytes 27/28 to 0/1 before SigToPub so wallet typed-data output verifies without client re-encoding.