### PR TITLE
governance: seed default self-aliases pre-Athos so typed signing works on fresh nodes

### DIFF
--- a/governance/root_manager.go
+++ b/governance/root_manager.go
@@ -220,12 +220,24 @@ func (s *RootManager) canResolveAliasesFromChain() bool {
 	return s.reg.AccountAliases(nil) != nil
 }
 
-// refreshActiveAliases updates active.aliases from chain only when Athos is live and alias resolution is available.
+// refreshActiveAliases updates active.aliases from chain when Athos is live and alias
+// resolution is available. Pre-Athos (or when the registry is unavailable) each root
+// address is its own alias (root == alias), which is the correct pre-Athos identity
+// for typed signing. Self-aliases are only seeded if the map is empty; once aliases
+// have been explicitly set (e.g. from chain) they are not overwritten.
 func (s *RootManager) refreshActiveAliases() {
-	if s == nil || s.active == nil || !s.canResolveAliasesFromChain() {
+	if s == nil || s.active == nil {
 		return
 	}
-	s.active.aliases = s.getAliasesOfRoots(s.active.rootAddresses)
+	if s.canResolveAliasesFromChain() {
+		s.active.aliases = s.getAliasesOfRoots(s.active.rootAddresses)
+		return
+	}
+	// Seed self-aliases so typed signing works before Athos activates or registry is
+	// available, but only when the map has not already been populated from the chain.
+	if len(s.active.aliases) == 0 {
+		s.active.aliases = s.getAliasesOfRoots(s.active.rootAddresses)
+	}
 }
 
 func (s *RootManager) updateAliasesOfRootSets() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Bug found during QA of PR #38** (`epic-b-typed-signing-dapp-apis`, hex JSON signatures and wallet v normalization).

### Root Cause

`refreshActiveAliases()` was guarded by `canResolveAliasesFromChain()`, making it a no-op until Athos block is reached and the registry is available. On fresh or unsynced testnet nodes, this left `active.aliases` as `nil`/empty.

`validateTypedActiveSigner` → `knownSigners()` iterates `s.aliases` to find the signer. With an empty map the loop never runs, returning an empty slice, which causes every typed governance submission to be rejected with `"typed … contains unknown signer"` — even when the signer is a valid root node.

### Fix

When `canResolveAliasesFromChain()` is false **and** the map is empty (never populated), seed self-aliases (`root == alias`) via the existing pre-Athos code path in `getAliasesOfRoots`. The "only if empty" guard preserves explicitly-set alias maps (e.g. tests with `root != alias`) from being overwritten.

### QA Evidence

Tested end-to-end on testnet (network ID 35443) with two nodes built from `epic-b-typed-signing-dapp-apis`:

| Step | Result |
|---|---|
| Root node + RN1_KEY unlocked, Gateway with HTTP API exposed | ✅ Both nodes running |
| Direct p2p qgov/6 connection between nodes | ✅ Confirmed |
| `govPub_l0GovernanceCapabilities` → `externalSubmissionEnabled: true`, `qgovTypedRelayVersion: 6` | ✅ |
| `govPub_signingPayloadExclusionListV1WithDigest` returns EIP-712 typed data | ✅ |
| Sign digest with RN1_KEY, submit via `govPub_submitTypedSignedExclusionList` | ✅ Returns proposal hash `0xad049c…` |
| Root node receives typed attestation via qgov/6, mints raw sig (self-bridge) | ✅ "Received a new proposed exclusion list hash=0xad049c…" |
| Proposal visible on both nodes: `signers: ["0x64d4…"]` | ✅ |
| `govPub_getGovernanceProposalStatus` shows `phase: proposed`, `signedCount: 1/6`, `needsSignature: false` | ✅ |

### Additional Finding: Testnet Sync Issue

Testnet nodes cannot sync past block 53126 due to `"mismatching signer list on checkpoint block"`. The testnet's active root list has evolved beyond the initial 2-node list in `params.TestnetRootNodes`. This is a separate issue — governance state (via `qgov` p2p) still propagates correctly and the typed-signing flow is fully functional once the alias initialization is fixed.

### Tests

- ✅ All 56 `./governance` tests pass (`go test -timeout=20m -p 1 ./governance`)
- ✅ `./ethclient ./internal/web3ext ./cmd/utils` pass

**Base branch:** `epic-b-typed-signing-dapp-apis` (the PR #38 feature branch)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f83f847-d0b5-4b49-ad0b-43e32f810968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f83f847-d0b5-4b49-ad0b-43e32f810968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

