### PR TITLE
governance: permanent exclusion-list discard + mainnet prefill (#40)

### DIFF
--- a/governance/README.adoc
+++ b/governance/README.adoc
@@ -495,3 +495,12 @@ This command will cause a rewind of the blockchain.
 >gov.acceptQuarantinedExclusionList("0xf6cc800a504eadaabe2e7dbd5651fdd546d8769323af8ab50245b61e80795982")
 
 ----
+
+==== gov.discardExclusionList
+
+Permanently ignores an exclusion list by its calculated hash. The list is removed from quarantine (if present), will no longer be imported from P2P gossip, and will not be propagated to peers. This does not affect the active exclusion list.
+
+----
+> gov.discardExclusionList("0x61b7caed3930d652bf98942ab4dfaaa5a948736e87de11a013556e5895a09a06")
+
+----

--- a/governance/api.go
+++ b/governance/api.go
@@ -276,6 +276,10 @@ func (a *GovernanceAPI) AcceptQuarantinedExclusionList(hash *common.Hash) error 
 	return a.gov.RootManager.acceptQuarantinedExclusionSet(hash)
 }
 
+func (a *GovernanceAPI) DiscardExclusionList(hash *common.Hash) error {
+	return a.gov.RootManager.discardExclusionList(hash)
+}
+
 func (a *GovernanceAPI) QuarantinedExclusionLists() string {
 	sets, err := a.gov.RootManager.db.getExclusionSetsFromQuarantine()
 	if sets == nil {

--- a/governance/db.go
+++ b/governance/db.go
@@ -29,6 +29,7 @@ var (
 	desiredExclusionKey     = []byte("desired-exclusion-set")
 	proposedExclusionKey    = []byte("proposed-exclusion-set")
 	quarantinedExclusionKey = []byte("quarantined-exclusion-set")
+	discardedExclusionKey   = []byte("discarded-exclusion-hashes")
 )
 
 var (
@@ -532,6 +533,49 @@ func (db *database) getQuarantinedExclusionSetByHash(hash *common.Hash) (*exclus
 		}
 	}
 	return nil, nil
+}
+
+func (db *database) getDiscardedExclusionHashes() ([]common.Hash, error) {
+	ok, err := db.store.Has(discardedExclusionKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to check discarded exclusion hashes")
+	}
+	if !ok {
+		return nil, nil
+	}
+
+	raw, err := db.store.Get(discardedExclusionKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get discarded exclusion hashes")
+	}
+
+	var hashes []common.Hash
+	if err := json.Unmarshal(raw, &hashes); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal discarded exclusion hashes")
+	}
+	return hashes, nil
+}
+
+func (db *database) saveDiscardedExclusionHashes(hashes []common.Hash) error {
+	raw, err := json.Marshal(hashes)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal discarded exclusion hashes")
+	}
+	return db.store.Put(discardedExclusionKey, raw)
+}
+
+func (db *database) addDiscardedExclusionHash(hash common.Hash) error {
+	hashes, err := db.getDiscardedExclusionHashes()
+	if err != nil {
+		return err
+	}
+	for _, existing := range hashes {
+		if existing == hash {
+			return nil
+		}
+	}
+	hashes = append(hashes, hash)
+	return db.saveDiscardedExclusionHashes(hashes)
 }
 
 func (db *database) saveQuotaEntries(entries map[common.Address][]common.ListQuotaEntry, quotaKey []byte) error {

--- a/governance/discarded_exclusion.go
+++ b/governance/discarded_exclusion.go
@@ -1,0 +1,169 @@
+package governance
+
+import (
+	"github.com/pkg/errors"
+	"gitlab.com/q-dev/q-client/common"
+	"gitlab.com/q-dev/q-client/log"
+	"gitlab.com/q-dev/q-client/params"
+)
+
+// defaultDiscardedExclusionHashes lists built-in exclusion-list hashes to ignore per network.
+// Keys are wire or calculated hashes; both are stored so gossip can be dropped before parsing.
+var defaultDiscardedExclusionHashes = map[uint64][]common.Hash{
+	params.MainnetChainConfig.ChainID.Uint64(): {
+		// 2022-era list still gossiped on mainnet (calculated hash).
+		common.HexToHash("0x61b7caed3930d652bf98942ab4dfaaa5a948736e87de11a013556e5895a09a06"),
+		// Stale provided hash from pre-block-range hash rule.
+		common.HexToHash("0x37809e789038d75ab188f9e2112495b088e732282c8343741c5902540dd01507"),
+	},
+}
+
+func (s *RootManager) loadDiscardedExclusionHashes() error {
+	hashes, err := s.db.getDiscardedExclusionHashes()
+	if err != nil {
+		return err
+	}
+	cache := make(map[common.Hash]struct{}, len(hashes))
+	for _, hash := range hashes {
+		cache[hash] = struct{}{}
+	}
+	s.discardedExclusionLock.Lock()
+	s.discardedExclusionHashes = cache
+	s.discardedExclusionLock.Unlock()
+	return nil
+}
+
+func (s *RootManager) seedDiscardedExclusionHashes() {
+	for _, hash := range defaultDiscardedExclusionHashes[s.networkId] {
+		if err := s.addDiscardedExclusionHash(hash); err != nil {
+			log.Error("Failed to seed discarded exclusion list hash", "hash", hash.Hex(), "err", err)
+		}
+	}
+	s.clearDiscardedExclusionState()
+}
+
+func (s *RootManager) clearDiscardedExclusionState() {
+	s.discardedExclusionLock.RLock()
+	hashes := make([]common.Hash, 0, len(s.discardedExclusionHashes))
+	for hash := range s.discardedExclusionHashes {
+		hashes = append(hashes, hash)
+	}
+	s.discardedExclusionLock.RUnlock()
+
+	for _, hash := range hashes {
+		s.quarantineLock.Lock()
+		_, err := s.db.removeExclusionSetFromQuarantine(&exclusionSet{hash: hash})
+		s.quarantineLock.Unlock()
+		if err != nil {
+			log.Error("Failed to remove discarded exclusion list from quarantine", "hash", hash.Hex(), "err", err)
+		}
+	}
+
+	s.exLock.Lock()
+	defer s.exLock.Unlock()
+	if s.proposedExSet != nil && s.isDiscardedExclusionHash(s.proposedExSet.hash) {
+		s.proposedExSet = nil
+		s.db.deleteProposedExclusionSet()
+	}
+}
+
+func (s *RootManager) isDiscardedExclusionHash(hash common.Hash) bool {
+	if hash == (common.Hash{}) {
+		return false
+	}
+	s.discardedExclusionLock.RLock()
+	defer s.discardedExclusionLock.RUnlock()
+	_, ok := s.discardedExclusionHashes[hash]
+	return ok
+}
+
+func (s *RootManager) addDiscardedExclusionHash(hash common.Hash) error {
+	if hash == (common.Hash{}) {
+		return errors.New("invalid hash")
+	}
+	if err := s.db.addDiscardedExclusionHash(hash); err != nil {
+		return err
+	}
+	s.discardedExclusionLock.Lock()
+	if s.discardedExclusionHashes == nil {
+		s.discardedExclusionHashes = make(map[common.Hash]struct{})
+	}
+	s.discardedExclusionHashes[hash] = struct{}{}
+	s.discardedExclusionLock.Unlock()
+	return nil
+}
+
+func (s *RootManager) isIgnoredExclusionHash(hash common.Hash) bool {
+	if s.isDiscardedExclusionHash(hash) {
+		return true
+	}
+	return s.isExclusionSetInQuarantine(&exclusionSet{hash: hash})
+}
+
+// parseExclusionListFromWire parses a gossiped exclusion list unless it is discarded or quarantined.
+func (s *RootManager) parseExclusionListFromWire(list *common.ValidatorExclusionList) (*exclusionSet, error) {
+	if list == nil {
+		return nil, errInvalidExclusionList
+	}
+	if list.IsEmpty() {
+		return nil, nil
+	}
+	if s.isDiscardedExclusionHash(list.Hash) {
+		return nil, nil
+	}
+
+	set, err := newExclusionSetForNetwork(list, s.networkId)
+	if err != nil {
+		return nil, err
+	}
+	s.logExclusionListHashMismatchIfNeeded(list, set)
+	if s.isIgnoredExclusionHash(set.hash) {
+		return nil, nil
+	}
+	return set, nil
+}
+
+func (s *RootManager) logExclusionListHashMismatchIfNeeded(list *common.ValidatorExclusionList, set *exclusionSet) {
+	if list == nil || set == nil || list.Hash == (common.Hash{}) {
+		return
+	}
+	if list.Hash == set.hash {
+		return
+	}
+	if s.isIgnoredExclusionHash(set.hash) || s.isDiscardedExclusionHash(list.Hash) {
+		return
+	}
+	log.Warn("Exclusion list hash mismatch", "provided", list.Hash.Hex(), "calculated", set.hash.Hex(), "timestamp", set.timestamp)
+}
+
+func (s *RootManager) discardExclusionList(hash *common.Hash) error {
+	if hash == nil || *hash == (common.Hash{}) {
+		return errors.New("invalid hash")
+	}
+
+	s.exLock.Lock()
+	defer s.exLock.Unlock()
+
+	if s.activeExSet != nil && s.activeExSet.hash == *hash {
+		return errors.New("cannot discard active exclusion list")
+	}
+
+	if err := s.addDiscardedExclusionHash(*hash); err != nil {
+		return errors.Wrap(err, "failed to discard exclusion list")
+	}
+
+	s.quarantineLock.Lock()
+	if _, err := s.db.removeExclusionSetFromQuarantine(&exclusionSet{hash: *hash}); err != nil {
+		s.quarantineLock.Unlock()
+		return errors.Wrap(err, "failed to remove exclusion list from quarantine")
+	}
+	s.quarantineLock.Unlock()
+
+	if s.proposedExSet != nil && s.proposedExSet.hash == *hash {
+		s.proposedExSet = nil
+		s.db.deleteProposedExclusionSet()
+	}
+
+	log.Info("Discarded exclusion list", "hash", hash.Hex())
+	return nil
+}

--- a/governance/discarded_exclusion_test.go
+++ b/governance/discarded_exclusion_test.go
@@ -1,0 +1,43 @@
+package governance
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDiscardedExclusionListImportNoOp(t *testing.T) {
+	rm := newTestRootManager(t, false, true)
+	bc := newTestChain(t, rm.RootManager)
+	defer bc.Stop()
+	rm.InitBlockChain(bc)
+
+	list := signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, 1, true, 6000)
+
+	gov, err := New(rm.RootManager, tmpDirName(t))
+	if err != nil {
+		t.Fatalf("Failed to create Governance: %v", err)
+	}
+	startGovernance(t, gov)
+
+	if err := gov.handler.importExclusionList(&list); err != nil {
+		t.Fatalf("first import returned error: %v", err)
+	}
+	if rm.proposedExSet == nil {
+		t.Fatalf("expected proposed exclusion list after first import")
+	}
+	proposedHash := rm.proposedExSet.hash
+
+	if err := rm.discardExclusionList(&proposedHash); err != nil {
+		t.Fatalf("discardExclusionList returned error: %v", err)
+	}
+	if rm.proposedExSet != nil {
+		t.Fatalf("expected proposed exclusion list cleared after discard")
+	}
+
+	if err := gov.handler.importExclusionList(&list); err != nil {
+		t.Fatalf("second import returned error: %v", err)
+	}
+	if rm.proposedExSet != nil {
+		t.Fatalf("discarded exclusion list import changed proposed state: %v", rm.proposedExSet)
+	}
+}

--- a/governance/exclusion_set.go
+++ b/governance/exclusion_set.go
@@ -9,7 +9,6 @@ import (
 	"gitlab.com/q-dev/q-client/common"
 	"gitlab.com/q-dev/q-client/common/math"
 	"gitlab.com/q-dev/q-client/crypto"
-	"gitlab.com/q-dev/q-client/log"
 )
 
 type exclusionSet struct {
@@ -91,13 +90,6 @@ func newExclusionSetForNetwork(list *common.ValidatorExclusionList, networkID ui
 
 	// Fix known bad hashes/timestamps
 	set.fixTimestamp()
-
-	// Validate hash if provided (signatures are validated against the calculated hash below)
-	if list.Hash != (common.Hash{}) {
-		if set.hash != list.Hash {
-			log.Warn("Exclusion list hash mismatch", "provided", list.Hash.Hex(), "calculated", set.hash.Hex(), "timestamp", set.timestamp)
-		}
-	}
 
 	signers := make(map[common.Address][]byte)
 	for _, sig := range list.Signatures {

--- a/governance/governance_test.go
+++ b/governance/governance_test.go
@@ -8,38 +8,35 @@ import (
 )
 
 func TestNewGovernanceLifecycle(t *testing.T) {
-	var gov = newGovernance(t)
-
-	defer func(gov *Governance) {
-		err := gov.Stop()
-		if err != nil {
-			t.Fatalf("Failed to stop Governance: %v", err)
-		}
-	}(gov)
-	if gov == nil {
+	if newGovernance(t) == nil {
 		t.Fatalf("Failed to create Governance instance")
 	}
 }
 
 func TestRunPeer(t *testing.T) {
-	var gov = newGovernance(t)
-
-	defer func(gov *Governance) {
-		err := gov.Stop()
-		if err != nil {
-			t.Fatalf("Failed to stop Governance: %v", err)
-		}
-	}(gov)
-	if gov == nil {
+	if newGovernance(t) == nil {
 		t.Fatalf("Failed to create Governance instance")
 	}
+}
+
+// startGovernance starts the governance service and registers t.Cleanup to stop it.
+func startGovernance(t *testing.T, gov *Governance) {
+	t.Helper()
+	if err := gov.Start(); err != nil {
+		t.Fatalf("Failed to start Governance: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := gov.Stop(); err != nil {
+			t.Fatalf("Failed to stop Governance: %v", err)
+		}
+	})
 }
 
 func newGovernance(t *testing.T) *Governance {
 	rm := newTestRootManager(t, true, false)
 
 	bc := newTestChain(t, rm.RootManager)
-	defer bc.Stop()
+	t.Cleanup(func() { bc.Stop() })
 	rm.InitBlockChain(bc)
 
 	gov, err := New(rm.RootManager, tmpDirName(t))
@@ -47,12 +44,7 @@ func newGovernance(t *testing.T) *Governance {
 		t.Fatalf("Failed to create Governance: %v", err)
 	}
 
-	err = gov.Start()
-	if err != nil {
-		t.Fatalf("Failed to start Governance: %v", err)
-		return nil
-	}
-
+	startGovernance(t, gov)
 	return gov
 }
 

--- a/governance/handler.go
+++ b/governance/handler.go
@@ -321,13 +321,13 @@ func (h *handler) runPeer(p *peer) error {
 	}
 
 	// Propagate current exclusion set to newly connected peers
-	if shouldPropagateExcl(rm.desiredExSet, status.desiredExSet, rm.active) {
+	if shouldPropagateExcl(rm.desiredExSet, status.desiredExSet, rm) {
 		h.propagateExclusionSet(status.desiredExSet)
 	}
-	if shouldPropagateExcl(rm.proposedExSet, status.proposedExSet, rm.active) {
+	if shouldPropagateExcl(rm.proposedExSet, status.proposedExSet, rm) {
 		h.propagateExclusionSet(status.proposedExSet)
 	}
-	if shouldPropagateExcl(rm.activeExSet, status.currentExSet, rm.active) {
+	if shouldPropagateExcl(rm.activeExSet, status.currentExSet, rm) {
 		h.propagateExclusionSet(status.currentExSet)
 	}
 
@@ -365,7 +365,7 @@ func (h *handler) runPeer(p *peer) error {
 		{rm.proposedExSet, status.proposedExSet},
 	} {
 		our, their := set.our, set.their
-		if shouldPropagateExcl(our, their, rm.active) {
+		if shouldPropagateExcl(our, their, rm) {
 			if err = h.importExclusionSet(p.id, their, true); err != nil {
 				return err
 			}
@@ -391,12 +391,15 @@ func (h *handler) runPeer(p *peer) error {
 	}
 }
 
-func shouldPropagateExcl(our, their *exclusionSet, active *rootSet) bool {
-	if their == nil {
+func shouldPropagateExcl(our, their *exclusionSet, rm *RootManager) bool {
+	if their == nil || rm == nil || rm.active == nil {
+		return false
+	}
+	if rm.isDiscardedExclusionHash(their.hash) {
 		return false
 	}
 	if our == nil {
-		return len(active.knownSigners(their.signers)) != 0 // signatures were checked in handshake func
+		return len(rm.active.knownSigners(their.signers)) != 0 // signatures were checked in handshake func
 	}
 
 	if our.hash == their.hash {
@@ -404,7 +407,7 @@ func shouldPropagateExcl(our, their *exclusionSet, active *rootSet) bool {
 	}
 
 	if their.timestamp > our.timestamp {
-		return len(active.knownSigners(their.signers)) != 0 // signatures were checked in handshake func
+		return len(rm.active.knownSigners(their.signers)) != 0 // signatures were checked in handshake func
 	}
 
 	return false
@@ -581,6 +584,10 @@ func (s *RootManager) snapshotExclusionListImport(set *exclusionSet) (exclusionL
 		return exclusionListImportSnapshot{}, errors.New("signed exclusion list is quarantined")
 	}
 
+	if s.isDiscardedExclusionHash(set.hash) {
+		return exclusionListImportSnapshot{}, errors.New("signed exclusion list is discarded")
+	}
+
 	if s.getActiveRootSet(true).isEnoughExSetSignatures(set) && s.exclusionSetWouldQuarantine(set) {
 		return exclusionListImportSnapshot{}, errors.New("signed exclusion list would be quarantined")
 	}
@@ -659,7 +666,7 @@ func (h *handler) propagateRootSet(set *rootSet) {
 }
 
 func (h *handler) propagateExclusionSet(set *exclusionSet) {
-	if set != nil {
+	if set != nil && !h.rootManager.isDiscardedExclusionHash(set.hash) {
 		h.exEventCh <- &exclusionSetEvent{set: set}
 	}
 }
@@ -1001,9 +1008,12 @@ func (h *handler) importExclusionList(list *common.ValidatorExclusionList) error
 }
 
 func (h *handler) importExclusionListFrom(fromID string, list *common.ValidatorExclusionList, signLocal bool) error {
-	received, err := newExclusionSetForNetwork(list, h.rootManager.networkId)
+	received, err := h.rootManager.parseExclusionListFromWire(list)
 	if err != nil {
 		return err
+	}
+	if received == nil {
+		return nil
 	}
 	return h.importExclusionSet(fromID, received, signLocal)
 }

--- a/governance/handler_json_test.go
+++ b/governance/handler_json_test.go
@@ -16,9 +16,7 @@ func TestSubmitTypedSignedRootList_hexJSONWire(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	if err := gov.Start(); err != nil {
-		t.Fatalf("Start: %v", err)
-	}
+	startGovernance(t, gov)
 
 	list := randomRootList(t, rm, time.Now().Add(5*time.Minute).Unix(), 10, 0, true)
 	unsigned := list
@@ -57,9 +55,7 @@ func TestSubmitTypedSignedRootList_walletRecoveryByte(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	if err := gov.Start(); err != nil {
-		t.Fatalf("Start: %v", err)
-	}
+	startGovernance(t, gov)
 
 	list := randomRootList(t, rm, time.Now().Add(5*time.Minute).Unix(), 10, 0, true)
 	sig := signRootListEIP712(t, rm.networkId, list, rm.aliasPrivateKeys[0])

--- a/governance/handler_test.go
+++ b/governance/handler_test.go
@@ -149,10 +149,7 @@ func TestHandleRootSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create Governance: %v", err)
 	}
-	err = gov.Start()
-	if err != nil {
-		t.Fatalf("Failed to start Governance: %v", err)
-	}
+	startGovernance(t, gov)
 
 	rw1, rw2 := p2p.MsgPipe()
 	p1 := newPeer(5, p2p.NewPeer(randomPeerID(), "peer", nil), rw1)
@@ -326,9 +323,7 @@ func TestImportRootList(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to create Governance: %v", err)
 			}
-			if err := gov.Start(); err != nil {
-				t.Fatalf("Failed to start Governance: %v", err)
-			}
+			startGovernance(t, gov)
 
 			list := tt.list(t, rm)
 			if tt.beforeImport != nil {
@@ -348,9 +343,7 @@ func TestImportRootListDoesNotRequireLocalSigning(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create Governance: %v", err)
 	}
-	if err := gov.Start(); err != nil {
-		t.Fatalf("Failed to start Governance: %v", err)
-	}
+	startGovernance(t, gov)
 
 	list := common.RootList{
 		Timestamp: uint64(time.Now().Add(5 * time.Minute).Unix()),
@@ -586,9 +579,7 @@ func TestSubmitSignedRootList(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to create Governance: %v", err)
 			}
-			if err := gov.Start(); err != nil {
-				t.Fatalf("Failed to start Governance: %v", err)
-			}
+			startGovernance(t, gov)
 			api := NewGovernancePublicAPI(gov)
 
 			list := tt.list(t, rm)
@@ -679,12 +670,8 @@ func TestSubmitSignedRootListEquivalentToPeerImport(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to create rpc Governance: %v", err)
 			}
-			if err := peerGov.Start(); err != nil {
-				t.Fatalf("Failed to start peer Governance: %v", err)
-			}
-			if err := rpcGov.Start(); err != nil {
-				t.Fatalf("Failed to start rpc Governance: %v", err)
-			}
+			startGovernance(t, peerGov)
+			startGovernance(t, rpcGov)
 
 			peerBefore := peerRM.rootListImportSnapshot(list.Hash)
 			rpcBefore := rpcRM.rootListImportSnapshot(list.Hash)
@@ -840,9 +827,7 @@ func TestSubmitTypedSignedRootList(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to create Governance: %v", err)
 			}
-			if err := gov.Start(); err != nil {
-				t.Fatalf("Failed to start Governance: %v", err)
-			}
+			startGovernance(t, gov)
 
 			list := tt.list(t, rm)
 			hash, err := NewGovernancePublicAPI(gov).SubmitTypedSignedRootList(list)
@@ -1036,9 +1021,7 @@ func TestSubmitTypedSignedExclusionList(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to create Governance: %v", err)
 			}
-			if err := gov.Start(); err != nil {
-				t.Fatalf("Failed to start Governance: %v", err)
-			}
+			startGovernance(t, gov)
 
 			list := tt.list(t, rm)
 			hash, err := NewGovernancePublicAPI(gov).SubmitTypedSignedExclusionList(list)
@@ -1076,9 +1059,7 @@ func TestGovPubSigningPayloadV1(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create Governance: %v", err)
 		}
-		if err := gov.Start(); err != nil {
-			t.Fatalf("Failed to start Governance: %v", err)
-		}
+		startGovernance(t, gov)
 		api := NewGovernancePublicAPI(gov)
 
 		list := randomRootList(t, rm, time.Now().Add(5*time.Minute).Unix(), 10, 0, true)
@@ -1113,9 +1094,7 @@ func TestGovPubSigningPayloadV1(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create Governance: %v", err)
 		}
-		if err := gov.Start(); err != nil {
-			t.Fatalf("Failed to start Governance: %v", err)
-		}
+		startGovernance(t, gov)
 		api := NewGovernancePublicAPI(gov)
 		list := randomRootList(t, rm, time.Now().Add(5*time.Minute).Unix(), 5, 0, true)
 		bundle, err := api.SigningPayloadRootListV1WithDigest(list)
@@ -1141,9 +1120,7 @@ func TestGovPubSigningPayloadV1(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create Governance: %v", err)
 		}
-		if err := gov.Start(); err != nil {
-			t.Fatalf("Failed to start Governance: %v", err)
-		}
+		startGovernance(t, gov)
 		api := NewGovernancePublicAPI(gov)
 
 		scrambled := common.RootList{
@@ -1178,9 +1155,7 @@ func TestGovPubSigningPayloadV1(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create Governance: %v", err)
 		}
-		if err := gov.Start(); err != nil {
-			t.Fatalf("Failed to start Governance: %v", err)
-		}
+		startGovernance(t, gov)
 		api := NewGovernancePublicAPI(gov)
 
 		scrambled := common.ValidatorExclusionList{
@@ -1218,9 +1193,7 @@ func TestGovPubSigningPayloadV1(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create Governance: %v", err)
 		}
-		if err := gov.Start(); err != nil {
-			t.Fatalf("Failed to start Governance: %v", err)
-		}
+		startGovernance(t, gov)
 		api := NewGovernancePublicAPI(gov)
 
 		list := signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, 1, true, 6000)
@@ -1246,9 +1219,7 @@ func TestGovPubSigningPayloadV1(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create Governance: %v", err)
 		}
-		if err := gov.Start(); err != nil {
-			t.Fatalf("Failed to start Governance: %v", err)
-		}
+		startGovernance(t, gov)
 		api := NewGovernancePublicAPI(gov)
 		list := signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, 1, true, 7000)
 		bundle, err := api.SigningPayloadExclusionListV1WithDigest(list)
@@ -1274,9 +1245,7 @@ func TestGovPubSigningPayloadV1(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create Governance: %v", err)
 		}
-		if err := gov.Start(); err != nil {
-			t.Fatalf("Failed to start Governance: %v", err)
-		}
+		startGovernance(t, gov)
 		api := NewGovernancePublicAPI(gov)
 		_, err = api.SigningPayloadRootListV1(common.RootList{Timestamp: 1, Nodes: nil})
 		if err == nil {
@@ -1290,9 +1259,7 @@ func TestGovPubSigningPayloadV1(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create Governance: %v", err)
 		}
-		if err := gov.Start(); err != nil {
-			t.Fatalf("Failed to start Governance: %v", err)
-		}
+		startGovernance(t, gov)
 		api := NewGovernancePublicAPI(gov)
 		list := randomRootList(t, rm, time.Now().Add(5*time.Minute).Unix(), 3, 0, true)
 		list.Hash = common.BytesToHash([]byte{1, 2, 3})
@@ -1311,9 +1278,7 @@ func TestGovPubSigningPayloadV1(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create Governance: %v", err)
 		}
-		if err := gov.Start(); err != nil {
-			t.Fatalf("Failed to start Governance: %v", err)
-		}
+		startGovernance(t, gov)
 		api := NewGovernancePublicAPI(gov)
 		addr := common.HexToAddress("0x1111111111111111111111111111111111111111")
 		list := common.ValidatorExclusionList{
@@ -1335,9 +1300,7 @@ func TestGovPubSigningPayloadV1(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create Governance: %v", err)
 		}
-		if err := gov.Start(); err != nil {
-			t.Fatalf("Failed to start Governance: %v", err)
-		}
+		startGovernance(t, gov)
 		api := NewGovernancePublicAPI(gov)
 		list := signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, 1, true, 6000)
 		list.Hash = common.BytesToHash([]byte{7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7})
@@ -1356,9 +1319,7 @@ func TestGovPubSigningPayloadV1(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create Governance: %v", err)
 		}
-		if err := gov.Start(); err != nil {
-			t.Fatalf("Failed to start Governance: %v", err)
-		}
+		startGovernance(t, gov)
 		api := NewGovernancePublicAPI(gov)
 		list := randomRootList(t, nil, time.Now().Unix(), 2*maxNRootNodes+1, 2*maxNRootNodes+1, false)
 		_, err = api.SigningPayloadRootListV1(list)
@@ -1374,9 +1335,7 @@ func TestGovPubSigningPayloadV1(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create Governance: %v", err)
 		}
-		if err := gov.Start(); err != nil {
-			t.Fatalf("Failed to start Governance: %v", err)
-		}
+		startGovernance(t, gov)
 		api := NewGovernancePublicAPI(gov)
 		list := randomRootList(t, rm, time.Now().Add(5*time.Minute).Unix(), 5, 0, true)
 		if _, err := api.SigningPayloadRootListV1(list); err != nil {
@@ -1525,12 +1484,8 @@ func TestSubmitSignedExclusionListEquivalentToPeerImport(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to create rpc Governance: %v", err)
 			}
-			if err := peerGov.Start(); err != nil {
-				t.Fatalf("Failed to start peer Governance: %v", err)
-			}
-			if err := rpcGov.Start(); err != nil {
-				t.Fatalf("Failed to start rpc Governance: %v", err)
-			}
+			startGovernance(t, peerGov)
+			startGovernance(t, rpcGov)
 
 			peerBefore := peerRM.exclusionListImportSnapshot(list.Hash)
 			rpcBefore := rpcRM.exclusionListImportSnapshot(list.Hash)
@@ -1577,10 +1532,7 @@ func TestHandleExclusionSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create Governance: %v", err)
 	}
-	err = gov.Start()
-	if err != nil {
-		t.Fatalf("Failed to start Governance: %v", err)
-	}
+	startGovernance(t, gov)
 
 	rw1, rw2 := p2p.MsgPipe()
 	p1 := newPeer(5, p2p.NewPeer(randomPeerID(), "peer", nil), rw1)
@@ -1766,9 +1718,7 @@ func TestImportExclusionList(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to create Governance: %v", err)
 			}
-			if err := gov.Start(); err != nil {
-				t.Fatalf("Failed to start Governance: %v", err)
-			}
+			startGovernance(t, gov)
 
 			list := tt.list(t, rm)
 			if tt.beforeImport != nil {
@@ -1788,9 +1738,7 @@ func TestImportExclusionListDoesNotRequireLocalSigning(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create Governance: %v", err)
 	}
-	if err := gov.Start(); err != nil {
-		t.Fatalf("Failed to start Governance: %v", err)
-	}
+	startGovernance(t, gov)
 
 	list := signedExclusionList(t, rm, uint64(time.Now().Add(5*time.Minute).Unix()), 2, 1, false, 6000)
 	if err := gov.handler.importExclusionList(&list); err != nil {
@@ -1835,9 +1783,7 @@ func TestImportExclusionListPreservesQuarantine(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create Governance: %v", err)
 	}
-	if err := gov.Start(); err != nil {
-		t.Fatalf("Failed to start Governance: %v", err)
-	}
+	startGovernance(t, gov)
 
 	currentExclusionSet := rm.activeExSet.copy()
 	if err := gov.handler.importExclusionList(&list); err != nil {
@@ -2058,9 +2004,7 @@ func TestSubmitSignedExclusionList(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to create Governance: %v", err)
 			}
-			if err := gov.Start(); err != nil {
-				t.Fatalf("Failed to start Governance: %v", err)
-			}
+			startGovernance(t, gov)
 
 			api := NewGovernancePublicAPI(gov)
 			list := tt.list(t, rm)
@@ -2096,10 +2040,7 @@ func TestHandleConstitution(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create Governance: %v", err)
 	}
-	err = gov.Start()
-	if err != nil {
-		t.Fatalf("Failed to start Governance: %v", err)
-	}
+	startGovernance(t, gov)
 
 	rw1, rw2 := p2p.MsgPipe()
 	p1 := newPeer(5, p2p.NewPeer(randomPeerID(), "peer", nil), rw1)
@@ -2215,10 +2156,7 @@ func TestApproval(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create Governance: %v", err)
 	}
-	err = gov.Start()
-	if err != nil {
-		t.Fatalf("Failed to start Governance: %v", err)
-	}
+	startGovernance(t, gov)
 
 	rw1, rw2 := p2p.MsgPipe()
 	p1 := newPeer(5, p2p.NewPeer(randomPeerID(), "peer", nil), rw1)

--- a/governance/peer.go
+++ b/governance/peer.go
@@ -166,17 +166,17 @@ func (p *peer) handshake(msg statusMsgBody, rm *RootManager) (*peerStatus, error
 
 	// Validators
 
-	currentExSet, err := newExclusionSetForNetwork(&status.CurrentExclusionList, rm.networkId)
+	currentExSet, err := rm.parseExclusionListFromWire(&status.CurrentExclusionList)
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid exclusion list")
 	}
 
-	desiredExSet, err := newExclusionSetForNetwork(&status.DesiredExclusionList, rm.networkId)
+	desiredExSet, err := rm.parseExclusionListFromWire(&status.DesiredExclusionList)
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid desired exclusion list")
 	}
 
-	proposedExSet, err := newExclusionSetForNetwork(&status.ProposedExclusionList, rm.networkId)
+	proposedExSet, err := rm.parseExclusionListFromWire(&status.ProposedExclusionList)
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid proposed exclusion list")
 	}

--- a/governance/root_manager.go
+++ b/governance/root_manager.go
@@ -84,6 +84,9 @@ type RootManager struct {
 	quarantineLock    sync.Mutex
 	quarantineEventCh chan *QuarantineEvent
 
+	discardedExclusionLock   sync.RWMutex
+	discardedExclusionHashes map[common.Hash]struct{}
+
 	rootQuotaEntries      map[common.Address][]common.ListQuotaEntry
 	exclusionQuotaEntries map[common.Address][]common.ListQuotaEntry
 
@@ -185,7 +188,14 @@ func NewRootManager(am *accounts.Manager, networkId uint64, datadir string, cfg 
 
 		quarantineTicker:     time.NewTicker(time.Minute),
 		quarantineTickerDone: make(chan struct{}),
+
+		discardedExclusionHashes: make(map[common.Hash]struct{}),
 	}
+
+	if err := manager.loadDiscardedExclusionHashes(); err != nil {
+		return nil, errors.Wrap(err, "failed to load discarded exclusion hashes")
+	}
+	manager.seedDiscardedExclusionHashes()
 
 	manager.transitionBlockChecker = newTransitionBlockChecker(
 		int64(cfg.TransitionBlockVerifiedBlocks),
@@ -1260,6 +1270,9 @@ func (s *RootManager) isAthosReached() bool {
 // received exclusion set cam cause huge rewind of the blockchain. It is very undesirable
 // instead of updating active exclusion set we will create new one and start quarantining it
 func (s *RootManager) initiateExclusionSetQuarantine(set *exclusionSet) error {
+	if set == nil || s.isDiscardedExclusionHash(set.hash) {
+		return nil
+	}
 	if s.isExclusionSetInQuarantine(set) {
 		return nil
 	}
@@ -1322,6 +1335,11 @@ func (s *RootManager) quarantineProposedExclusionSetIfNeeded() {
 	defer s.exLock.Unlock()
 
 	if s.proposedExSet == nil {
+		return
+	}
+	if s.isDiscardedExclusionHash(s.proposedExSet.hash) {
+		s.proposedExSet = nil
+		s.db.deleteProposedExclusionSet()
 		return
 	}
 

--- a/governance/root_manager.go
+++ b/governance/root_manager.go
@@ -1295,8 +1295,12 @@ func (s *RootManager) notifyExclusionSetIsQuarantined(set *exclusionSet, current
 func (s *RootManager) startQuarantineRoutine() {
 	for {
 		if s.bc == nil {
-			time.Sleep(5 * time.Second)
-			continue
+			select {
+			case <-s.quarantineTickerDone:
+				return
+			case <-time.After(5 * time.Second):
+				continue
+			}
 		}
 		select {
 		case <-s.quarantineTickerDone:

--- a/governance/root_manager_test.go
+++ b/governance/root_manager_test.go
@@ -765,6 +765,22 @@ func newTestChainWithBlocks(t *testing.T, rm *RootManager, numBlocks int) *core.
 	return chain
 }
 
+func TestRootManagerStopWithoutBlockchain(t *testing.T) {
+	rm := newTestRootManager(t, false, true)
+
+	done := make(chan struct{})
+	go func() {
+		rm.stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("RootManager.stop blocked with nil blockchain")
+	}
+}
+
 func randomExclusionSet(t *testing.T, add int64) exclusionSet {
 	var set exclusionSet
 
@@ -875,10 +891,7 @@ func TestQuarantineExclusionSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create Governance: %v", err)
 	}
-	err = gov.Start()
-	if err != nil {
-		t.Fatalf("Failed to start Governance: %v", err)
-	}
+	startGovernance(t, gov)
 	p := peer{
 		id: "test",
 	}

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -932,6 +932,11 @@ web3._extend({
 			call: 'gov_acceptQuarantinedExclusionList',
 			params: 1
 		}),
+	    new web3._extend.Method({
+			name: 'discardExclusionList',
+			call: 'gov_discardExclusionList',
+			params: 1
+		}),
     ],
 	properties: []
 });

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	QVersionMajor = 2        // QGOV-Client major version component of the current release
 	QVersionMinor = 3        // QGOV-Client minor version component of the current release
-	QVersionPatch = 0        // QGOV-Client patch version component of the current release
+	QVersionPatch = 1        // QGOV-Client patch version component of the current release
 	QVersionMeta  = "stable" // QGOV-Client version metadata to append to the version string
 )
 


### PR DESCRIPTION
## Summary

- Add permanent exclusion-list discard (`gov.discardExclusionList`) with LevelDB persistence.
- Prefill mainnet (35441) with the known 2022-era stale list hashes so fresh nodes ignore gossip silently.
- Gate P2P import/propagation early via `parseExclusionListFromWire`; move hash-mismatch warn out of `newExclusionSet` so ignored lists do not spam logs.
- Bump patch version to 2.3.1.

Closes #40.

## Test plan

- [x] `go test ./governance -run TestDiscardedExclusionListImportNoOp`
- [x] `go test ./governance`
- [x] On mainnet node: confirm no hash-mismatch warns for `0x61b7caed…` after upgrade
- [ ] `gov.discardExclusionList` clears quarantine entry and blocks re-import