### PR TITLE
miner: restore Validators.makeSnapshot system-tx injection (#45)

### DIFF
--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -56,8 +56,6 @@ const (
 	inmemorySignatures = 4096 // Number of recent block signatures to keep in memory
 
 	wiggleTime = 300 * time.Millisecond // Out-of-turn seal delay step (see outOfTurnSealDelay)
-
-	compressedRecencyBand = 10 // Recency 1..10 use wiggle/4 per rank; above uses full wiggle
 )
 
 // Clique proof-of-authority protocol constants.
@@ -947,7 +945,7 @@ func (c *Clique) Seal(chain consensus.ChainHeaderReader, block *types.Block, res
 			}
 		}
 		recency := inTurnRecencyScore(number, signerIndex, len(signers))
-		ootDelay := outOfTurnSealDelay(recency)
+		ootDelay := outOfTurnSealDelay(recency, len(signers))
 		delay += ootDelay
 
 		log.Trace("Out-of-turn signing requested", "recency", recency, "delay", common.PrettyDuration(ootDelay))
@@ -1142,19 +1140,22 @@ func inTurnRecencyScore(number uint64, signerIndex int, signerCount int) uint64 
 }
 
 // outOfTurnSealDelay returns deterministic extra wait before broadcasting an out-of-turn block.
-// Lower recency (next in-turn farther away) seals sooner. Recency 1..10 use wiggle/4 per rank;
-// higher recency adds full wiggle steps (compressed band for normal eligible validators).
-func outOfTurnSealDelay(recency uint64) time.Duration {
+// Lower recency (next in-turn farther away) seals sooner. Recency 1..N/2 use wiggle/4 per rank;
+// higher recency adds full wiggle steps (compressed band for the typical eligible set).
+func outOfTurnSealDelay(recency uint64, signerCount int) time.Duration {
 	if recency == 0 {
 		return 0
 	}
+	compressedBand := uint64(signerCount / 2)
 	low := recency
-	if low > compressedRecencyBand {
-		low = compressedRecencyBand
+	if compressedBand > 0 && low > compressedBand {
+		low = compressedBand
 	}
 	delay := time.Duration(low) * (wiggleTime / 4)
-	if recency > compressedRecencyBand {
-		delay += time.Duration(recency-compressedRecencyBand) * wiggleTime
+	if compressedBand > 0 && recency > compressedBand {
+		delay += time.Duration(recency-compressedBand) * wiggleTime
+	} else if compressedBand == 0 {
+		delay = time.Duration(recency) * wiggleTime
 	}
 	return delay
 }

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -1124,7 +1124,10 @@ func toSet(signers []common.Address) map[common.Address]struct{} {
 	return set
 }
 
-func (c *Clique) ChooseBlockWithMostRecentSigner(chain *core.BlockChain, header *types.Header, externalHeader *types.Header) (*types.Header, error) {
+// PreferHeaderByInTurnRecency implements EIP-3436 rule #3: among two headers at the
+// same height, prefer the one whose signer had the least recent in-turn assignment.
+// Returns the preferred header (header on a tie or unknown external signer).
+func (c *Clique) PreferHeaderByInTurnRecency(chain *core.BlockChain, header *types.Header, externalHeader *types.Header) (*types.Header, error) {
 	// In this case, header numbers should be the same, so take it from local header
 	number := header.Number.Uint64()
 	if number == 0 {

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -1124,8 +1124,14 @@ func toSet(signers []common.Address) map[common.Address]struct{} {
 	return set
 }
 
-// PreferHeaderByInTurnRecency implements EIP-3436 rule #3: among two headers at the
-// same height, prefer the one whose signer had the least recent in-turn assignment.
+// PreferHeaderByInTurnRecency implements EIP-3436 rule #3 among two headers at the
+// same height using score = (number - signerIndex) % N.
+//
+// QGOV prefers the **smaller** score (most recently in-turn / next in-turn farthest
+// away). That matches the EIP rationale — decline validators closest to their next
+// in-turn slot — and intentionally diverges from the EIP's contradictory "choose
+// the largest value" formula line.
+//
 // Returns the preferred header (header on a tie or unknown external signer).
 func (c *Clique) PreferHeaderByInTurnRecency(chain *core.BlockChain, header *types.Header, externalHeader *types.Header) (*types.Header, error) {
 	// In this case, header numbers should be the same, so take it from local header
@@ -1172,7 +1178,8 @@ func (c *Clique) PreferHeaderByInTurnRecency(chain *core.BlockChain, header *typ
 	localPosition := (number - uint64(localIndex-1)) % uint64(len(snap.SignersList()))
 	externalPosition := (number - uint64(externalIndex-1)) % uint64(len(snap.SignersList()))
 
-	if localPosition < externalPosition {
+	// Prefer smaller score: next in-turn is farther away.
+	if externalPosition < localPosition {
 		return externalHeader, nil
 	}
 

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io"
 	"math/big"
-	"math/rand"
 	"sync"
 	"time"
 
@@ -56,7 +55,9 @@ const (
 	inmemorySnapshots  = 128  // Number of recent vote snapshots to keep in memory
 	inmemorySignatures = 4096 // Number of recent block signatures to keep in memory
 
-	wiggleTime = 500 * time.Millisecond // Random delay (per signer) to allow concurrent signers
+	wiggleTime = 300 * time.Millisecond // Out-of-turn seal delay step (see outOfTurnSealDelay)
+
+	compressedRecencyBand = 10 // Recency 1..10 use wiggle/4 per rank; above uses full wiggle
 )
 
 // Clique proof-of-authority protocol constants.
@@ -937,11 +938,19 @@ func (c *Clique) Seal(chain consensus.ChainHeaderReader, block *types.Block, res
 	// Sweet, the protocol permits us to sign the block, wait for our time
 	delay := time.Unix(int64(header.Time), 0).Sub(time.Now()) // nolint: gosimple
 	if header.Difficulty.Cmp(diffNoTurn) == 0 {
-		// It's not our turn explicitly to sign, delay it a bit
-		wiggle := time.Duration(len(snap.Signers)/2+1) * wiggleTime
-		delay += time.Duration(rand.Int63n(int64(wiggle))) + wiggleTime
+		signers := snap.SignersList()
+		var signerIndex int
+		for i, addr := range signers {
+			if addr == signer {
+				signerIndex = i + 1
+				break
+			}
+		}
+		recency := inTurnRecencyScore(number, signerIndex, len(signers))
+		ootDelay := outOfTurnSealDelay(recency)
+		delay += ootDelay
 
-		log.Trace("Out-of-turn signing requested", "wiggle", common.PrettyDuration(wiggle))
+		log.Trace("Out-of-turn signing requested", "recency", recency, "delay", common.PrettyDuration(ootDelay))
 	}
 	// Sign all the things!
 	sighash, err := signFn(accounts.Account{Address: signer}, accounts.MimetypeClique, CliqueRLP(header))
@@ -1124,6 +1133,32 @@ func toSet(signers []common.Address) map[common.Address]struct{} {
 	return set
 }
 
+// inTurnRecencyScore is EIP-3436 rule #3 score: (number - signerIndex) % N with 1-based index.
+func inTurnRecencyScore(number uint64, signerIndex int, signerCount int) uint64 {
+	if signerIndex == 0 || signerCount == 0 {
+		return 0
+	}
+	return (number - uint64(signerIndex-1)) % uint64(signerCount)
+}
+
+// outOfTurnSealDelay returns deterministic extra wait before broadcasting an out-of-turn block.
+// Lower recency (next in-turn farther away) seals sooner. Recency 1..10 use wiggle/4 per rank;
+// higher recency adds full wiggle steps (compressed band for normal eligible validators).
+func outOfTurnSealDelay(recency uint64) time.Duration {
+	if recency == 0 {
+		return 0
+	}
+	low := recency
+	if low > compressedRecencyBand {
+		low = compressedRecencyBand
+	}
+	delay := time.Duration(low) * (wiggleTime / 4)
+	if recency > compressedRecencyBand {
+		delay += time.Duration(recency-compressedRecencyBand) * wiggleTime
+	}
+	return delay
+}
+
 // PreferHeaderByInTurnRecency implements EIP-3436 rule #3 among two headers at the
 // same height using score = (number - signerIndex) % N.
 //
@@ -1175,8 +1210,8 @@ func (c *Clique) PreferHeaderByInTurnRecency(chain *core.BlockChain, header *typ
 		return header, nil
 	}
 
-	localPosition := (number - uint64(localIndex-1)) % uint64(len(snap.SignersList()))
-	externalPosition := (number - uint64(externalIndex-1)) % uint64(len(snap.SignersList()))
+	localPosition := inTurnRecencyScore(number, localIndex, len(snap.SignersList()))
+	externalPosition := inTurnRecencyScore(number, externalIndex, len(snap.SignersList()))
 
 	// Prefer smaller score: next in-turn is farther away.
 	if externalPosition < localPosition {

--- a/consensus/clique/clique_test.go
+++ b/consensus/clique/clique_test.go
@@ -332,6 +332,86 @@ func sealCompetingBlock(t *testing.T, parent *types.Block, engine *Clique, db et
 	return blocks[0].WithSeal(header)
 }
 
+// TestPreferHeaderByInTurnRecencyPrefersLowerScore locks the QGOV rule-3 direction:
+// smaller (number-index)%N wins (next in-turn farther away), not the EIP "largest" line.
+func TestPreferHeaderByInTurnRecencyPrefersLowerScore(t *testing.T) {
+	var (
+		db           = rawdb.NewMemoryDatabase()
+		reg          = contracts.NewTestModeRegistry()
+		engine       = New(params.AllCliqueProtocolChanges.Clique, db, &consensus.NoopExclusionSetProvider{}, reg)
+		signersCount = 7
+		keys         = make(map[common.Address]*ecdsa.PrivateKey)
+		addresses    = make([]common.Address, 0, signersCount)
+	)
+	engine.fakeDiff = true
+
+	for len(addresses) != signersCount {
+		key, _ := crypto.GenerateKey()
+		addr := crypto.PubkeyToAddress(key.PublicKey)
+		keys[addr] = key
+		addresses = append(addresses, addr)
+	}
+	sort.Sort(signersAscending(addresses))
+
+	genSpec := &core.Genesis{
+		Config:    params.AllCliqueProtocolChanges,
+		ExtraData: make([]byte, extraVanity+common.AddressLength*signersCount+extraSeal),
+		Alloc: map[common.Address]core.GenesisAccount{
+			addresses[0]: {Balance: big.NewInt(10000000000000000)},
+		},
+		BaseFee:    big.NewInt(params.InitialBaseFee),
+		Difficulty: big.NewInt(0),
+	}
+	for i := 0; i < signersCount; i++ {
+		copy(genSpec.ExtraData[extraVanity+i*common.AddressLength:], addresses[i][:])
+	}
+	genSpec.MustCommit(db, trie.NewDatabase(db, trie.HashDefaults))
+
+	chain, err := core.NewBlockChain(db, nil, genSpec, nil, engine, vm.Config{}, nil, nil)
+	if err != nil {
+		t.Fatalf("new chain: %v", err)
+	}
+	defer chain.Stop()
+
+	commonBlocks := generateChain(t, params.AllCliqueProtocolChanges, genSpec.ToBlock(), engine, db, signersCount*2, addresses, keys, reg, false)
+	if _, err := chain.InsertChain(commonBlocks); err != nil {
+		t.Fatalf("insert common: %v", err)
+	}
+	parent := commonBlocks[len(commonBlocks)-1]
+	number := parent.NumberU64() + 1
+
+	// Indices 1 and 3 are distinct OOT for typical heights; pick the lower score as winner.
+	idxLow, idxHigh := 1, 3
+	score := func(index int) uint64 {
+		return (number - uint64(index)) % uint64(signersCount)
+	}
+	if score(idxLow) == score(idxHigh) {
+		t.Fatalf("test setup: scores collided at number %d", number)
+	}
+	wantIdx, otherIdx := idxLow, idxHigh
+	if score(idxHigh) < score(idxLow) {
+		wantIdx, otherIdx = idxHigh, idxLow
+	}
+
+	wantBlock := sealCompetingBlock(t, parent, engine, db, addresses[wantIdx], keys[addresses[wantIdx]], reg)
+	otherBlock := sealCompetingBlock(t, parent, engine, db, addresses[otherIdx], keys[addresses[otherIdx]], reg)
+
+	preferred, err := engine.PreferHeaderByInTurnRecency(chain, wantBlock.Header(), otherBlock.Header())
+	if err != nil {
+		t.Fatalf("prefer: %v", err)
+	}
+	if preferred.Hash() != wantBlock.Hash() {
+		t.Fatalf("prefer(want, other): got %x, want lower-score %x (scores %d vs %d)", preferred.Hash(), wantBlock.Hash(), score(wantIdx), score(otherIdx))
+	}
+	preferred, err = engine.PreferHeaderByInTurnRecency(chain, otherBlock.Header(), wantBlock.Header())
+	if err != nil {
+		t.Fatalf("prefer reverse: %v", err)
+	}
+	if preferred.Hash() != wantBlock.Hash() {
+		t.Fatalf("prefer(other, want): got %x, want lower-score %x", preferred.Hash(), wantBlock.Hash())
+	}
+}
+
 // Generates blocks with the required signer and difficulty in the middle
 func generateChain(t *testing.T, config *params.ChainConfig, parent *types.Block, engine *Clique, db ethdb.Database, numBlocks int, addresses []common.Address, keys map[common.Address]*ecdsa.PrivateKey, reg *contracts.Registry, side bool) []*types.Block {
 	current := 1

--- a/consensus/clique/clique_test.go
+++ b/consensus/clique/clique_test.go
@@ -23,6 +23,7 @@ import (
 	"math/big"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -383,7 +384,7 @@ func TestPreferHeaderByInTurnRecencyPrefersLowerScore(t *testing.T) {
 	// Indices 1 and 3 are distinct OOT for typical heights; pick the lower score as winner.
 	idxLow, idxHigh := 1, 3
 	score := func(index int) uint64 {
-		return (number - uint64(index)) % uint64(signersCount)
+		return inTurnRecencyScore(number, index, signersCount)
 	}
 	if score(idxLow) == score(idxHigh) {
 		t.Fatalf("test setup: scores collided at number %d", number)
@@ -409,6 +410,32 @@ func TestPreferHeaderByInTurnRecencyPrefersLowerScore(t *testing.T) {
 	}
 	if preferred.Hash() != wantBlock.Hash() {
 		t.Fatalf("prefer(other, want): got %x, want lower-score %x", preferred.Hash(), wantBlock.Hash())
+	}
+}
+
+func TestOutOfTurnSealDelay(t *testing.T) {
+	tests := []struct {
+		recency uint64
+		want    time.Duration
+	}{
+		{0, 0},
+		{1, 75 * time.Millisecond},
+		{5, 375 * time.Millisecond},
+		{10, 750 * time.Millisecond},
+		{11, 1050 * time.Millisecond},
+		{15, 2250 * time.Millisecond},
+		{20, 3750 * time.Millisecond},
+	}
+	for _, tc := range tests {
+		if got := outOfTurnSealDelay(tc.recency); got != tc.want {
+			t.Errorf("recency %d: got %v, want %v", tc.recency, got, tc.want)
+		}
+	}
+	if outOfTurnSealDelay(2)-outOfTurnSealDelay(1) != wiggleTime/4 {
+		t.Fatalf("compressed band neighbors should differ by wiggle/4")
+	}
+	if outOfTurnSealDelay(11)-outOfTurnSealDelay(10) != wiggleTime {
+		t.Fatalf("recency 10→11 should add full wiggle step")
 	}
 }
 

--- a/consensus/clique/clique_test.go
+++ b/consensus/clique/clique_test.go
@@ -183,7 +183,7 @@ func TestForkChoice(t *testing.T) {
 	var chain *core.BlockChain
 
 	shouldPreserve := func(header *types.Header, externalHeader *types.Header) bool {
-		rHeader, err := engine.ChooseBlockWithMostRecentSigner(chain, header, externalHeader)
+		rHeader, err := engine.PreferHeaderByInTurnRecency(chain, header, externalHeader)
 		if err != nil {
 			log.Warn("Failed to retrieve recent signer list for preserve check for local header", "number", header.Number.Uint64(), "hash", header.Hash(), "err", err)
 			return false
@@ -223,6 +223,113 @@ func TestForkChoice(t *testing.T) {
 	if chain.CurrentBlock().Hash() != minHash {
 		t.Errorf("Rule 4 failed")
 	}
+}
+
+// TestForkChoiceRule3DifferentSigners verifies EIP-3436 rule #3: equal-TD tips from
+// different validators converge on PreferHeaderByInTurnRecency regardless of import order.
+func TestForkChoiceRule3DifferentSigners(t *testing.T) {
+	var (
+		reg          = contracts.NewTestModeRegistry()
+		signersCount = 7
+		keys         = make(map[common.Address]*ecdsa.PrivateKey)
+		addresses    = make([]common.Address, 0, signersCount)
+	)
+
+	for len(addresses) != signersCount {
+		key, _ := crypto.GenerateKey()
+		addr := crypto.PubkeyToAddress(key.PublicKey)
+		keys[addr] = key
+		addresses = append(addresses, addr)
+	}
+	sort.Sort(signersAscending(addresses))
+
+	genSpec := &core.Genesis{
+		Config:    params.AllCliqueProtocolChanges,
+		ExtraData: make([]byte, extraVanity+common.AddressLength*signersCount+extraSeal),
+		Alloc: map[common.Address]core.GenesisAccount{
+			addresses[0]: {Balance: big.NewInt(10000000000000000)},
+		},
+		BaseFee:    big.NewInt(params.InitialBaseFee),
+		Difficulty: big.NewInt(0),
+	}
+	for i := 0; i < signersCount; i++ {
+		copy(genSpec.ExtraData[extraVanity+i*common.AddressLength:], addresses[i][:])
+	}
+
+	runOrder := func(t *testing.T, loserFirst bool) {
+		t.Helper()
+		db := rawdb.NewMemoryDatabase()
+		engine := New(params.AllCliqueProtocolChanges.Clique, db, &consensus.NoopExclusionSetProvider{}, reg)
+		engine.fakeDiff = true
+		genSpec.MustCommit(db, trie.NewDatabase(db, trie.HashDefaults))
+
+		var chain *core.BlockChain
+		shouldPreserve := func(header *types.Header, externalHeader *types.Header) bool {
+			rHeader, err := engine.PreferHeaderByInTurnRecency(chain, header, externalHeader)
+			if err != nil {
+				t.Fatalf("PreferHeaderByInTurnRecency: %v", err)
+			}
+			return rHeader == header
+		}
+
+		chain, err := core.NewBlockChain(db, nil, genSpec, nil, engine, vm.Config{}, shouldPreserve, nil)
+		if err != nil {
+			t.Fatalf("new chain: %v", err)
+		}
+		defer chain.Stop()
+
+		commonBlocks := generateChain(t, params.AllCliqueProtocolChanges, genSpec.ToBlock(), engine, db, signersCount*2, addresses, keys, reg, false)
+		if _, err := chain.InsertChain(commonBlocks); err != nil {
+			t.Fatalf("insert common: %v", err)
+		}
+		parent := commonBlocks[len(commonBlocks)-1]
+
+		blockA := sealCompetingBlock(t, parent, engine, db, addresses[1], keys[addresses[1]], reg)
+		blockB := sealCompetingBlock(t, parent, engine, db, addresses[3], keys[addresses[3]], reg)
+
+		preferred, err := engine.PreferHeaderByInTurnRecency(chain, blockA.Header(), blockB.Header())
+		if err != nil {
+			t.Fatalf("prefer: %v", err)
+		}
+		want, loser := blockA, blockB
+		if preferred.Hash() != blockA.Hash() {
+			want, loser = blockB, blockA
+		}
+
+		first, second := want, loser
+		if loserFirst {
+			first, second = loser, want
+		}
+		if _, err := chain.InsertChain([]*types.Block{first}); err != nil {
+			t.Fatalf("insert first: %v", err)
+		}
+		if _, err := chain.InsertChain([]*types.Block{second}); err != nil {
+			t.Fatalf("insert second: %v", err)
+		}
+		if chain.CurrentBlock().Hash() != want.Hash() {
+			t.Fatalf("import order loserFirst=%v: head %x, want %x", loserFirst, chain.CurrentBlock().Hash(), want.Hash())
+		}
+	}
+
+	t.Run("winnerThenLoser", func(t *testing.T) { runOrder(t, false) })
+	t.Run("loserThenWinner", func(t *testing.T) { runOrder(t, true) })
+}
+
+// sealCompetingBlock creates one equal-difficulty Clique block on parent sealed by signer.
+func sealCompetingBlock(t *testing.T, parent *types.Block, engine *Clique, db ethdb.Database, signer common.Address, key *ecdsa.PrivateKey, reg *contracts.Registry) *types.Block {
+	t.Helper()
+	blocks, _ := core.GenerateChain(params.AllCliqueProtocolChanges, parent, engine, db, 1, nil)
+	header := blocks[0].Header()
+	header.ParentHash = parent.Hash()
+	header.Extra = make([]byte, extraVanity+extraSeal)
+	header.Difficulty = diffNoTurn
+	header.Coinbase = reg.RewardReceiver()
+	sig, err := crypto.Sign(SealHash(header).Bytes(), key)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	copy(header.Extra[len(header.Extra)-extraSeal:], sig)
+	return blocks[0].WithSeal(header)
 }
 
 // Generates blocks with the required signer and difficulty in the middle

--- a/consensus/clique/clique_test.go
+++ b/consensus/clique/clique_test.go
@@ -414,7 +414,8 @@ func TestPreferHeaderByInTurnRecencyPrefersLowerScore(t *testing.T) {
 }
 
 func TestOutOfTurnSealDelay(t *testing.T) {
-	tests := []struct {
+	const n21 = 21
+	tests21 := []struct {
 		recency uint64
 		want    time.Duration
 	}{
@@ -426,16 +427,24 @@ func TestOutOfTurnSealDelay(t *testing.T) {
 		{15, 2250 * time.Millisecond},
 		{20, 3750 * time.Millisecond},
 	}
-	for _, tc := range tests {
-		if got := outOfTurnSealDelay(tc.recency); got != tc.want {
-			t.Errorf("recency %d: got %v, want %v", tc.recency, got, tc.want)
+	for _, tc := range tests21 {
+		if got := outOfTurnSealDelay(tc.recency, n21); got != tc.want {
+			t.Errorf("N=%d recency %d: got %v, want %v", n21, tc.recency, got, tc.want)
 		}
 	}
-	if outOfTurnSealDelay(2)-outOfTurnSealDelay(1) != wiggleTime/4 {
+	if outOfTurnSealDelay(2, n21)-outOfTurnSealDelay(1, n21) != wiggleTime/4 {
 		t.Fatalf("compressed band neighbors should differ by wiggle/4")
 	}
-	if outOfTurnSealDelay(11)-outOfTurnSealDelay(10) != wiggleTime {
-		t.Fatalf("recency 10→11 should add full wiggle step")
+	if outOfTurnSealDelay(11, n21)-outOfTurnSealDelay(10, n21) != wiggleTime {
+		t.Fatalf("recency at band boundary should add full wiggle step")
+	}
+
+	const n7 = 7
+	if got := outOfTurnSealDelay(3, n7); got != 225*time.Millisecond {
+		t.Fatalf("N=7 recency 3: got %v, want 225ms", got)
+	}
+	if got := outOfTurnSealDelay(4, n7); got != 525*time.Millisecond {
+		t.Fatalf("N=7 recency 4: got %v, want 525ms", got)
 	}
 }
 

--- a/core/forkchoice.go
+++ b/core/forkchoice.go
@@ -49,8 +49,9 @@ type ForkChoice struct {
 	// local td is equal to the extern one. It can be nil for light
 	// client
 
-	// As we use Clique as engine, we need to obey rule #3 of Eip3436
-	// Choose the block whose validator had the least recent in-turn block assignment
+	// As we use Clique as engine, we need to obey EIP-3436 rule #3 (QGOV interpretation):
+	// prefer the block whose signer has the smaller (number-index)%N score — next
+	// in-turn farthest away. See PreferHeaderByInTurnRecency.
 	// This function is introduced because original preserve doesn't know anything about the external header
 	preserve func(header *types.Header, externalHeader *types.Header) bool
 }
@@ -100,7 +101,7 @@ func (f *ForkChoice) ReorgNeeded(currentHeader *types.Header, externalHeader *ty
 				// Same in-turn recency (typically same signer): rule #4, lower hash wins.
 				reorg = externalHeader.Hash().Big().Cmp(currentHeader.Hash().Big()) < 0
 			} else if externPreserve {
-				// Rule #3: external header's signer has the least recent in-turn assignment.
+				// Rule #3: external header wins PreferHeaderByInTurnRecency (smaller score).
 				reorg = true
 			} else {
 				// Current wins rule #3, or no preserve callback — keep current head.

--- a/core/forkchoice.go
+++ b/core/forkchoice.go
@@ -90,18 +90,20 @@ func (f *ForkChoice) ReorgNeeded(currentHeader *types.Header, externalHeader *ty
 		if externalNum < currentNum {
 			reorg = true
 		} else if externalNum == currentNum {
-			// Preserve check is modified in order to attempt of applying rule#3 from https://eips.ethereum.org/EIPS/eip-3436
-			// If header numbers are the same, then choose the block whose validator had the least recent in-turn block assignment
+			// Equal TD and height: EIP-3436 rules #3 then #4.
+			// preserve(a, b) is true when a wins (or ties) PreferHeaderByInTurnRecency against b.
 			var currentPreserve, externPreserve bool
 			if f.preserve != nil {
 				currentPreserve, externPreserve = f.preserve(currentHeader, externalHeader), f.preserve(externalHeader, currentHeader)
 			}
-			// If both headers are from the same validator, then choose the block with the lower hash
 			if currentPreserve && externPreserve {
-				// EIP-3436 rule #4
-				// Apply external chain if it has the lower hash
+				// Same in-turn recency (typically same signer): rule #4, lower hash wins.
 				reorg = externalHeader.Hash().Big().Cmp(currentHeader.Hash().Big()) < 0
+			} else if externPreserve {
+				// Rule #3: external header's signer has the least recent in-turn assignment.
+				reorg = true
 			} else {
+				// Current wins rule #3, or no preserve callback — keep current head.
 				reorg = false
 			}
 		}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -448,7 +448,7 @@ func (s *Ethereum) shouldPreserve(header *types.Header, externalHeader *types.He
 }
 
 func (s *Ethereum) ShouldPreserveClique(header *types.Header, externalHeader *types.Header) bool {
-	// If we use Clique as engine, we need to check rule #3 of Eip3436: https://eips.ethereum.org/EIPS/eip-3436
+	// Clique EIP-3436 rule #3 via PreferHeaderByInTurnRecency (QGOV: prefer smaller score).
 	if c, ok := s.engine.(*clique.Clique); ok {
 		rHeader, err := c.PreferHeaderByInTurnRecency(s.blockchain, header, externalHeader)
 		if err != nil {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -450,7 +450,7 @@ func (s *Ethereum) shouldPreserve(header *types.Header, externalHeader *types.He
 func (s *Ethereum) ShouldPreserveClique(header *types.Header, externalHeader *types.Header) bool {
 	// If we use Clique as engine, we need to check rule #3 of Eip3436: https://eips.ethereum.org/EIPS/eip-3436
 	if c, ok := s.engine.(*clique.Clique); ok {
-		rHeader, err := c.ChooseBlockWithMostRecentSigner(s.blockchain, header, externalHeader)
+		rHeader, err := c.PreferHeaderByInTurnRecency(s.blockchain, header, externalHeader)
 		if err != nil {
 			log.Warn("Failed to retrieve recent signer list for preserve check for local header", "number", header.Number.Uint64(), "hash", header.Hash(), "err", err)
 			return false

--- a/internal/utils/system_transaction_test.go
+++ b/internal/utils/system_transaction_test.go
@@ -1,0 +1,115 @@
+package utils
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+
+	"gitlab.com/q-dev/q-client/accounts"
+	"gitlab.com/q-dev/q-client/accounts/abi"
+	"gitlab.com/q-dev/q-client/accounts/keystore"
+	"gitlab.com/q-dev/q-client/common"
+	"gitlab.com/q-dev/q-client/consensus"
+	"gitlab.com/q-dev/q-client/consensus/ethash"
+	"gitlab.com/q-dev/q-client/core/rawdb"
+	"gitlab.com/q-dev/q-client/core/state"
+	"gitlab.com/q-dev/q-client/core/types"
+	"gitlab.com/q-dev/q-client/crypto"
+	"gitlab.com/q-dev/q-client/params"
+	"gitlab.com/q-dev/system-contracts/generated"
+)
+
+type stubValidatorEngine struct {
+	consensus.Engine
+	signer     common.Address
+	validators *common.Address
+}
+
+func (s *stubValidatorEngine) Signer() common.Address { return s.signer }
+
+func (s *stubValidatorEngine) Validators() *common.Address { return s.validators }
+
+func TestPrepareSystemTxAtEpochBoundary(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	signerAddr := crypto.PubkeyToAddress(key.PublicKey)
+	validatorsAddr := common.HexToAddress("0x3Bce2CeeFb1EADb3313CcdcA54108F5aD2fc45DC")
+
+	dir := t.TempDir()
+	ks := keystore.NewKeyStore(dir, keystore.LightScryptN, keystore.LightScryptP)
+	account, err := ks.ImportECDSA(key, "pwd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ks.Unlock(account, "pwd"); err != nil {
+		t.Fatal(err)
+	}
+	am := accounts.NewManager(&accounts.Config{InsecureUnlockAllowed: true}, ks)
+
+	db := rawdb.NewMemoryDatabase()
+	statedb, err := state.New(types.EmptyRootHash, state.NewDatabase(db), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &params.ChainConfig{
+		ChainID: big.NewInt(35443),
+		Clique:  &params.CliqueConfig{Period: 5, Epoch: 101},
+	}
+	engine := &stubValidatorEngine{
+		Engine:     ethash.NewFaker(),
+		signer:     signerAddr,
+		validators: &validatorsAddr,
+	}
+
+	makeHeader := func(number uint64) *types.Header {
+		return &types.Header{Number: big.NewInt(int64(number)), Time: 1}
+	}
+
+	packSelector := func() []byte {
+		a, err := abi.JSON(strings.NewReader(generated.ValidatorsABI))
+		if err != nil {
+			t.Fatal(err)
+		}
+		input, err := a.Pack("makeSnapshot")
+		if err != nil {
+			t.Fatal(err)
+		}
+		return input
+	}()
+
+	t.Run("epoch boundary produces makeSnapshot", func(t *testing.T) {
+		// (100+1)%101 == 0 → epoch-end block
+		header := makeHeader(100)
+		preparer := New(cfg, engine, statedb, header, types.LatestSigner(cfg), nil)
+		txs := preparer.PrepareSystemTx(am, nil)
+		lazy := txs[signerAddr]
+		if len(lazy) != 1 {
+			t.Fatalf("expected 1 system tx, got %d (accounts=%v)", len(lazy), len(txs))
+		}
+		tx := lazy[0].Resolve()
+		if tx == nil {
+			t.Fatal("lazy tx resolved to nil")
+		}
+		if *tx.To() != validatorsAddr {
+			t.Fatalf("to=%s want=%s", tx.To().Hex(), validatorsAddr.Hex())
+		}
+		if string(tx.Data()) != string(packSelector) {
+			t.Fatalf("unexpected calldata: %x", tx.Data())
+		}
+		if tx.Gas() != 1477210 {
+			t.Fatalf("gas=%d", tx.Gas())
+		}
+	})
+
+	t.Run("non-epoch boundary yields nothing", func(t *testing.T) {
+		header := makeHeader(99)
+		preparer := New(cfg, engine, statedb, header, types.LatestSigner(cfg), nil)
+		txs := preparer.PrepareSystemTx(am, nil)
+		if len(txs) != 0 {
+			t.Fatalf("expected no system txs mid-epoch, got %d", len(txs))
+		}
+	})
+}

--- a/miner/system_tx_wiring_test.go
+++ b/miner/system_tx_wiring_test.go
@@ -1,0 +1,166 @@
+package miner
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"math/big"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"gitlab.com/q-dev/q-client/accounts"
+	"gitlab.com/q-dev/q-client/accounts/abi"
+	"gitlab.com/q-dev/q-client/accounts/keystore"
+	"gitlab.com/q-dev/q-client/common"
+	"gitlab.com/q-dev/q-client/consensus"
+	"gitlab.com/q-dev/q-client/consensus/ethash"
+	"gitlab.com/q-dev/q-client/core/rawdb"
+	"gitlab.com/q-dev/q-client/core/types"
+	"gitlab.com/q-dev/q-client/event"
+	"gitlab.com/q-dev/q-client/params"
+	"gitlab.com/q-dev/system-contracts/generated"
+)
+
+// TestFillTransactionsWiresPrepareSystemTx is a regression guard for the v2.2 geth-merge
+// fallout that left SystemTxPreparer as dead code and stopped Validators.makeSnapshot.
+// If fillTransactions stops calling prepareSystemTx, this test fails.
+func TestFillTransactionsWiresPrepareSystemTx(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	workerPath := filepath.Join(filepath.Dir(thisFile), "worker.go")
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, workerPath, nil, 0)
+	if err != nil {
+		t.Fatalf("parse worker.go: %v", err)
+	}
+
+	var fillFn *ast.FuncDecl
+	ast.Inspect(file, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Name == nil || fn.Name.Name != "fillTransactions" {
+			return true
+		}
+		fillFn = fn
+		return false
+	})
+	if fillFn == nil || fillFn.Body == nil {
+		t.Fatal("fillTransactions not found in worker.go")
+	}
+
+	wired := false
+	ast.Inspect(fillFn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch fun := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			if fun.Sel != nil && fun.Sel.Name == "prepareSystemTx" {
+				wired = true
+				return false
+			}
+		case *ast.Ident:
+			if fun.Name == "prepareSystemTx" {
+				wired = true
+				return false
+			}
+		}
+		return true
+	})
+	if !wired {
+		t.Fatal("fillTransactions must call prepareSystemTx to inject Validators.makeSnapshot system txs")
+	}
+}
+
+type stubValidatorEngine struct {
+	consensus.Engine
+	signer     common.Address
+	validators *common.Address
+}
+
+func (s *stubValidatorEngine) Signer() common.Address { return s.signer }
+
+func (s *stubValidatorEngine) Validators() *common.Address { return s.validators }
+
+// TestPrepareSystemTxProducesMakeSnapshot verifies the miner helper builds a signed
+// Validators.makeSnapshot tx at an epoch boundary (functional counterpart to the AST guard).
+func TestPrepareSystemTxProducesMakeSnapshot(t *testing.T) {
+	var (
+		db     = rawdb.NewMemoryDatabase()
+		config = *params.AllCliqueProtocolChanges
+	)
+	config.Clique = &params.CliqueConfig{Period: 1, Epoch: 101}
+	config.Clique.RewardReceiver = common.HexToAddress("92C35a964624D9cbF90c2A0525e116093FAF867E")
+
+	validatorsAddr := common.HexToAddress("0x3Bce2CeeFb1EADb3313CcdcA54108F5aD2fc45DC")
+	engine := &stubValidatorEngine{
+		Engine:     ethash.NewFaker(),
+		signer:     testBankAddress,
+		validators: &validatorsAddr,
+	}
+
+	dir := t.TempDir()
+	ks := keystore.NewKeyStore(dir, keystore.LightScryptN, keystore.LightScryptP)
+	account, err := ks.ImportECDSA(testBankKey, "pwd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ks.Unlock(account, "pwd"); err != nil {
+		t.Fatal(err)
+	}
+	am := accounts.NewManager(&accounts.Config{InsecureUnlockAllowed: true}, ks)
+
+	backend := newTestWorkerBackend(t, ethashChainConfig, ethash.NewFaker(), db, 0)
+	w := newWorker(testConfig, &config, engine, backend, new(event.TypeMux), nil, false, am, nil)
+	defer w.close()
+
+	parent := backend.chain.CurrentBlock()
+	header := &types.Header{
+		ParentHash: parent.Hash(),
+		Number:     big.NewInt(100), // (100+1)%101 == 0
+		GasLimit:   parent.GasLimit,
+		Time:       parent.Time + 1,
+		Coinbase:   testBankAddress,
+		Difficulty: big.NewInt(1),
+	}
+	env, err := w.makeEnv(parent, header, testBankAddress)
+	if err != nil {
+		t.Fatalf("makeEnv: %v", err)
+	}
+	defer env.discard()
+
+	systemTxs := w.prepareSystemTx(am, env)
+	lazy := systemTxs[testBankAddress]
+	if len(lazy) != 1 {
+		t.Fatalf("expected 1 system tx at epoch boundary, got %d", len(lazy))
+	}
+	tx := lazy[0].Resolve()
+	if tx == nil || tx.To() == nil || *tx.To() != validatorsAddr {
+		t.Fatalf("unexpected system tx recipient: %v", tx)
+	}
+
+	from, err := types.Sender(env.signer, tx)
+	if err != nil {
+		t.Fatalf("sender: %v", err)
+	}
+	if from != testBankAddress {
+		t.Fatalf("from=%s want=%s", from.Hex(), testBankAddress.Hex())
+	}
+
+	parsed, err := abi.JSON(strings.NewReader(generated.ValidatorsABI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := parsed.Pack("makeSnapshot")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(tx.Data()) != string(want) {
+		t.Fatalf("calldata=%x want=%x", tx.Data(), want)
+	}
+}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -36,6 +36,7 @@ import (
 	"gitlab.com/q-dev/q-client/core/types"
 	"gitlab.com/q-dev/q-client/core/vm"
 	"gitlab.com/q-dev/q-client/event"
+	"gitlab.com/q-dev/q-client/internal/utils"
 	"gitlab.com/q-dev/q-client/log"
 	"gitlab.com/q-dev/q-client/params"
 	"gitlab.com/q-dev/q-client/trie"
@@ -1011,6 +1012,7 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 // be customized with the plugin in the future.
 func (w *worker) fillTransactions(interrupt *atomic.Int32, env *environment) error {
 	pending := w.eth.TxPool().Pending(true)
+	systemTxs := w.prepareSystemTx(w.accountManager, env)
 
 	// Split the pending transactions into locals and remotes.
 	localTxs, remoteTxs := make(map[common.Address][]*txpool.LazyTransaction), pending
@@ -1034,7 +1036,23 @@ func (w *worker) fillTransactions(interrupt *atomic.Int32, env *environment) err
 			return err
 		}
 	}
+	// Add system transactions (Validators.makeSnapshot) in the last block of an epoch.
+	if len(systemTxs) > 0 {
+		txs := newTransactionsByPriceAndNonce(env.signer, systemTxs, env.header.BaseFee)
+		if err := w.commitTransactions(env, txs, interrupt); err != nil {
+			log.Warn("fail to apply system txs")
+			return err
+		}
+		log.Info("committed system txs")
+	} else {
+		log.Debug("no system txs")
+	}
 	return nil
+}
+
+func (w *worker) prepareSystemTx(accountManager *accounts.Manager, env *environment) map[common.Address][]*txpool.LazyTransaction {
+	systemTxPreparer := utils.New(w.chainConfig, w.engine, env.state, env.header, env.signer, w.gpp)
+	return systemTxPreparer.PrepareSystemTx(accountManager, w.eth.TxPool())
 }
 
 // generateWork generates a sealing block based on the given parameters.

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	QVersionMajor = 2        // QGOV-Client major version component of the current release
 	QVersionMinor = 3        // QGOV-Client minor version component of the current release
-	QVersionPatch = 2        // QGOV-Client patch version component of the current release
+	QVersionPatch = 3        // QGOV-Client patch version component of the current release
 	QVersionMeta  = "stable" // QGOV-Client version metadata to append to the version string
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	QVersionMajor = 2        // QGOV-Client major version component of the current release
 	QVersionMinor = 3        // QGOV-Client minor version component of the current release
-	QVersionPatch = 1        // QGOV-Client patch version component of the current release
+	QVersionPatch = 2        // QGOV-Client patch version component of the current release
 	QVersionMeta  = "stable" // QGOV-Client version metadata to append to the version string
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	QVersionMajor = 2        // QGOV-Client major version component of the current release
 	QVersionMinor = 3        // QGOV-Client minor version component of the current release
-	QVersionPatch = 3        // QGOV-Client patch version component of the current release
+	QVersionPatch = 4        // QGOV-Client patch version component of the current release
 	QVersionMeta  = "stable" // QGOV-Client version metadata to append to the version string
 )
 


### PR DESCRIPTION
## Summary

- Restore `prepareSystemTx` wiring in `miner/worker.go` `fillTransactions` so epoch-end sealers again inject `Validators.makeSnapshot`.
- This was dropped during the v2.2 geth-merge cleanup; `SystemTxPreparer` remained as dead code on ≥2.2 / 2.3.x.
- Add regression tests (AST wiring guard + preparer/miner functional coverage).
- Bump patch version to **2.3.4**.

Closes #45.

## Test plan

- [x] `go test ./internal/utils -run TestPrepareSystemTx`
- [x] `go test ./miner -run 'TestPrepareSystemTx|TestFillTransactionsWires'`
- [x] `go test ./miner`
- [ ] On testnet validator ≥2.3.4: at epoch boundary, expect `attempting to create system tx` / `committed system txs` and a `makeSnapshot` call on Validators