### PR TITLE
miner: default extradata uses "QGOV Client" + QVersion (#47)

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -26,7 +26,6 @@ import (
 	"gitlab.com/q-dev/q-client/accounts"
 	"gitlab.com/q-dev/q-client/accounts/abi/bind"
 	"gitlab.com/q-dev/q-client/common"
-	"gitlab.com/q-dev/q-client/common/hexutil"
 	"gitlab.com/q-dev/q-client/consensus"
 	"gitlab.com/q-dev/q-client/consensus/beacon"
 	"gitlab.com/q-dev/q-client/consensus/clique"
@@ -273,7 +272,7 @@ func New(stack *node.Node, config *ethconfig.Config, conn bind.ContractBackend, 
 		rm.InitDownloader(eth.Downloader())
 	}
 	// eth.miner = miner.New(eth, &config.Miner, eth.blockchain.Config(), eth.EventMux(), eth.engine, eth.isLocalBlock, eth.accountManager, gpProvider)
-	// eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
+	// eth.miner.SetExtra(params.MakeExtraData(config.Miner.ExtraData))
 
 	eth.APIBackend = &EthAPIBackend{stack.Config().ExtRPCEnabled(), stack.Config().AllowUnprotectedTxs, eth, gpProvider, nil}
 	if eth.APIBackend.allowUnprotectedTxs {
@@ -286,7 +285,7 @@ func New(stack *node.Node, config *ethconfig.Config, conn bind.ContractBackend, 
 	eth.APIBackend.gpo = gasprice.NewOracle(eth.APIBackend, gpoParams)
 
 	eth.miner = miner.New(eth, &config.Miner, chainConfig, eth.EventMux(), eth.engine, eth.isLocalBlock, eth.accountManager, gpProvider)
-	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
+	eth.miner.SetExtra(params.MakeExtraData(config.Miner.ExtraData))
 
 	// Setup DNS discovery iterators.
 	dnsclient := dnsdisc.NewClient(dnsdisc.Config{})
@@ -311,17 +310,6 @@ func New(stack *node.Node, config *ethconfig.Config, conn bind.ContractBackend, 
 	eth.shutdownTracker.MarkStartup()
 
 	return eth, nil
-}
-
-func makeExtraData(extra []byte) []byte {
-	if len(extra) == 0 {
-		return params.DefaultMinerExtraData()
-	}
-	if uint64(len(extra)) > params.MaximumExtraDataSize {
-		log.Warn("Miner extra data exceed limit", "extra", hexutil.Bytes(extra), "limit", params.MaximumExtraDataSize)
-		extra = nil
-	}
-	return extra
 }
 
 // APIs return the collection of RPC services the ethereum package offers.

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"runtime"
 	"sync"
 
 	"gitlab.com/q-dev/q-client/accounts"
@@ -59,7 +58,6 @@ import (
 	"gitlab.com/q-dev/q-client/p2p/dnsdisc"
 	"gitlab.com/q-dev/q-client/p2p/enode"
 	"gitlab.com/q-dev/q-client/params"
-	"gitlab.com/q-dev/q-client/rlp"
 	"gitlab.com/q-dev/q-client/rpc"
 )
 
@@ -317,13 +315,7 @@ func New(stack *node.Node, config *ethconfig.Config, conn bind.ContractBackend, 
 
 func makeExtraData(extra []byte) []byte {
 	if len(extra) == 0 {
-		// create default extradata
-		extra, _ = rlp.EncodeToBytes([]interface{}{
-			uint(params.VersionMajor<<16 | params.VersionMinor<<8 | params.VersionPatch),
-			"geth",
-			runtime.Version(),
-			runtime.GOOS,
-		})
+		return params.DefaultMinerExtraData()
 	}
 	if uint64(len(extra)) > params.MaximumExtraDataSize {
 		log.Warn("Miner extra data exceed limit", "extra", hexutil.Bytes(extra), "limit", params.MaximumExtraDataSize)

--- a/params/extradata.go
+++ b/params/extradata.go
@@ -1,0 +1,25 @@
+package params
+
+import (
+	"runtime"
+
+	"gitlab.com/q-dev/q-client/common/hexutil"
+	"gitlab.com/q-dev/q-client/log"
+	"gitlab.com/q-dev/q-client/rlp"
+)
+
+// DefaultMinerExtraData builds the default miner extradata used as Clique vanity
+// when --miner.extradata is unset: packed QVersion, "QGOV Client", and GOOS.
+// runtime.Version() is omitted so the RLP fits in MaximumExtraDataSize (32).
+func DefaultMinerExtraData() []byte {
+	extra, _ := rlp.EncodeToBytes([]interface{}{
+		uint(QVersionMajor<<16 | QVersionMinor<<8 | QVersionPatch),
+		"QGOV Client",
+		runtime.GOOS,
+	})
+	if uint64(len(extra)) > MaximumExtraDataSize {
+		log.Warn("Miner extra data exceed limit", "extra", hexutil.Bytes(extra), "limit", MaximumExtraDataSize)
+		return nil
+	}
+	return extra
+}

--- a/params/extradata.go
+++ b/params/extradata.go
@@ -8,15 +8,19 @@ import (
 	"gitlab.com/q-dev/q-client/rlp"
 )
 
-// DefaultMinerExtraData builds the default miner extradata used as Clique vanity
-// when --miner.extradata is unset: packed QVersion, "QGOV Client", and GOOS.
-// runtime.Version() is omitted so the RLP fits in MaximumExtraDataSize (32).
-func DefaultMinerExtraData() []byte {
-	extra, _ := rlp.EncodeToBytes([]interface{}{
-		uint(QVersionMajor<<16 | QVersionMinor<<8 | QVersionPatch),
-		"QGOV Client",
-		runtime.GOOS,
-	})
+// MakeExtraData returns miner extradata for Clique vanity.
+// If extra is empty, it builds the default RLP fingerprint: packed QVersion,
+// "QGOV Client", and GOOS. runtime.Version() is omitted so the blob fits in
+// MaximumExtraDataSize (32). Non-empty extra is returned as-is unless it exceeds
+// the size limit (then nil, with a warning).
+func MakeExtraData(extra []byte) []byte {
+	if len(extra) == 0 {
+		extra, _ = rlp.EncodeToBytes([]interface{}{
+			uint(QVersionMajor<<16 | QVersionMinor<<8 | QVersionPatch),
+			"QGOV Client",
+			runtime.GOOS,
+		})
+	}
 	if uint64(len(extra)) > MaximumExtraDataSize {
 		log.Warn("Miner extra data exceed limit", "extra", hexutil.Bytes(extra), "limit", MaximumExtraDataSize)
 		return nil

--- a/params/extradata_test.go
+++ b/params/extradata_test.go
@@ -1,0 +1,40 @@
+package params
+
+import (
+	"runtime"
+	"testing"
+
+	"gitlab.com/q-dev/q-client/rlp"
+)
+
+type defaultExtraPayload struct {
+	Version uint
+	Name    string
+	OS      string
+}
+
+func TestDefaultMinerExtraData(t *testing.T) {
+	got := DefaultMinerExtraData()
+	if len(got) == 0 {
+		t.Fatal("default extradata is empty")
+	}
+	if uint64(len(got)) > MaximumExtraDataSize {
+		t.Fatalf("default extradata len=%d exceeds MaximumExtraDataSize=%d", len(got), MaximumExtraDataSize)
+	}
+
+	var decoded defaultExtraPayload
+	if err := rlp.DecodeBytes(got, &decoded); err != nil {
+		t.Fatalf("decode default extradata: %v", err)
+	}
+
+	wantPacked := uint(QVersionMajor<<16 | QVersionMinor<<8 | QVersionPatch)
+	if decoded.Version != wantPacked {
+		t.Fatalf("packed version=%d want=%d", decoded.Version, wantPacked)
+	}
+	if decoded.Name != "QGOV Client" {
+		t.Fatalf("client name=%q want %q", decoded.Name, "QGOV Client")
+	}
+	if decoded.OS != runtime.GOOS {
+		t.Fatalf("os=%q want %q", decoded.OS, runtime.GOOS)
+	}
+}

--- a/params/extradata_test.go
+++ b/params/extradata_test.go
@@ -13,8 +13,8 @@ type defaultExtraPayload struct {
 	OS      string
 }
 
-func TestDefaultMinerExtraData(t *testing.T) {
-	got := DefaultMinerExtraData()
+func TestMakeExtraDataDefault(t *testing.T) {
+	got := MakeExtraData(nil)
 	if len(got) == 0 {
 		t.Fatal("default extradata is empty")
 	}
@@ -36,5 +36,20 @@ func TestDefaultMinerExtraData(t *testing.T) {
 	}
 	if decoded.OS != runtime.GOOS {
 		t.Fatalf("os=%q want %q", decoded.OS, runtime.GOOS)
+	}
+}
+
+func TestMakeExtraDataOverride(t *testing.T) {
+	custom := []byte("custom-extra")
+	got := MakeExtraData(custom)
+	if string(got) != string(custom) {
+		t.Fatalf("override not preserved: %q", got)
+	}
+}
+
+func TestMakeExtraDataTooLong(t *testing.T) {
+	tooLong := make([]byte, MaximumExtraDataSize+1)
+	if got := MakeExtraData(tooLong); got != nil {
+		t.Fatalf("expected nil for oversized extradata, got len=%d", len(got))
 	}
 }

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	QVersionMajor = 2        // QGOV-Client major version component of the current release
 	QVersionMinor = 3        // QGOV-Client minor version component of the current release
-	QVersionPatch = 4        // QGOV-Client patch version component of the current release
+	QVersionPatch = 5        // QGOV-Client patch version component of the current release
 	QVersionMeta  = "stable" // QGOV-Client version metadata to append to the version string
 )
 


### PR DESCRIPTION
## Summary

- Default miner extradata (Clique vanity) now RLP-encodes packed **QVersion**, client name **`QGOV Client`**, and `GOOS`.
- Drops upstream `"geth"` + Geth `Version*` stamp; omits `runtime.Version()` so the blob stays ≤ 32 bytes.
- Logic lives in `params.DefaultMinerExtraData()` with a unit test; `eth.makeExtraData` delegates to it.
- Patch bump to **2.3.5**.

Closes #47.

## Test plan

- [x] `go test ./params -run TestDefaultMinerExtraData`
- [ ] Seal a block without `--miner.extradata` and decode vanity RLP → `QGOV Client` + packed 2.3.5
- [ ] Confirm `--miner.extradata=...` still overrides