### PR TITLE
miner: restore 4-field Extra vanity with truncated Go tag (#49)

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -21,13 +21,11 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"runtime"
 	"sync"
 
 	"gitlab.com/q-dev/q-client/accounts"
 	"gitlab.com/q-dev/q-client/accounts/abi/bind"
 	"gitlab.com/q-dev/q-client/common"
-	"gitlab.com/q-dev/q-client/common/hexutil"
 	"gitlab.com/q-dev/q-client/consensus"
 	"gitlab.com/q-dev/q-client/consensus/beacon"
 	"gitlab.com/q-dev/q-client/consensus/clique"
@@ -59,7 +57,6 @@ import (
 	"gitlab.com/q-dev/q-client/p2p/dnsdisc"
 	"gitlab.com/q-dev/q-client/p2p/enode"
 	"gitlab.com/q-dev/q-client/params"
-	"gitlab.com/q-dev/q-client/rlp"
 	"gitlab.com/q-dev/q-client/rpc"
 )
 
@@ -275,7 +272,7 @@ func New(stack *node.Node, config *ethconfig.Config, conn bind.ContractBackend, 
 		rm.InitDownloader(eth.Downloader())
 	}
 	// eth.miner = miner.New(eth, &config.Miner, eth.blockchain.Config(), eth.EventMux(), eth.engine, eth.isLocalBlock, eth.accountManager, gpProvider)
-	// eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
+	// eth.miner.SetExtra(params.MakeExtraData(config.Miner.ExtraData))
 
 	eth.APIBackend = &EthAPIBackend{stack.Config().ExtRPCEnabled(), stack.Config().AllowUnprotectedTxs, eth, gpProvider, nil}
 	if eth.APIBackend.allowUnprotectedTxs {
@@ -288,7 +285,7 @@ func New(stack *node.Node, config *ethconfig.Config, conn bind.ContractBackend, 
 	eth.APIBackend.gpo = gasprice.NewOracle(eth.APIBackend, gpoParams)
 
 	eth.miner = miner.New(eth, &config.Miner, chainConfig, eth.EventMux(), eth.engine, eth.isLocalBlock, eth.accountManager, gpProvider)
-	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
+	eth.miner.SetExtra(params.MakeExtraData(config.Miner.ExtraData))
 
 	// Setup DNS discovery iterators.
 	dnsclient := dnsdisc.NewClient(dnsdisc.Config{})
@@ -313,23 +310,6 @@ func New(stack *node.Node, config *ethconfig.Config, conn bind.ContractBackend, 
 	eth.shutdownTracker.MarkStartup()
 
 	return eth, nil
-}
-
-func makeExtraData(extra []byte) []byte {
-	if len(extra) == 0 {
-		// create default extradata
-		extra, _ = rlp.EncodeToBytes([]interface{}{
-			uint(params.VersionMajor<<16 | params.VersionMinor<<8 | params.VersionPatch),
-			"geth",
-			runtime.Version(),
-			runtime.GOOS,
-		})
-	}
-	if uint64(len(extra)) > params.MaximumExtraDataSize {
-		log.Warn("Miner extra data exceed limit", "extra", hexutil.Bytes(extra), "limit", params.MaximumExtraDataSize)
-		extra = nil
-	}
-	return extra
 }
 
 // APIs return the collection of RPC services the ethereum package offers.

--- a/params/extradata.go
+++ b/params/extradata.go
@@ -1,0 +1,29 @@
+package params
+
+import (
+	"runtime"
+
+	"gitlab.com/q-dev/q-client/common/hexutil"
+	"gitlab.com/q-dev/q-client/log"
+	"gitlab.com/q-dev/q-client/rlp"
+)
+
+// MakeExtraData returns miner extradata for Clique vanity.
+// If extra is empty, it builds the default RLP fingerprint: packed QVersion,
+// "QGOV Client", and GOOS. runtime.Version() is omitted so the blob fits in
+// MaximumExtraDataSize (32). Non-empty extra is returned as-is unless it exceeds
+// the size limit (then nil, with a warning).
+func MakeExtraData(extra []byte) []byte {
+	if len(extra) == 0 {
+		extra, _ = rlp.EncodeToBytes([]interface{}{
+			uint(QVersionMajor<<16 | QVersionMinor<<8 | QVersionPatch),
+			"QGOV Client",
+			runtime.GOOS,
+		})
+	}
+	if uint64(len(extra)) > MaximumExtraDataSize {
+		log.Warn("Miner extra data exceed limit", "extra", hexutil.Bytes(extra), "limit", MaximumExtraDataSize)
+		return nil
+	}
+	return extra
+}

--- a/params/extradata.go
+++ b/params/extradata.go
@@ -2,6 +2,7 @@ package params
 
 import (
 	"runtime"
+	"strings"
 
 	"gitlab.com/q-dev/q-client/common/hexutil"
 	"gitlab.com/q-dev/q-client/log"
@@ -9,21 +10,50 @@ import (
 )
 
 // MakeExtraData returns miner extradata for Clique vanity.
-// If extra is empty, it builds the default RLP fingerprint: packed QVersion,
-// "QGOV Client", and GOOS. runtime.Version() is omitted so the blob fits in
-// MaximumExtraDataSize (32). Non-empty extra is returned as-is unless it exceeds
-// the size limit (then nil, with a warning).
+// If extra is empty, it builds the default RLP fingerprint matching the
+// historical 4-field geth shape:
+//
+//	[packedQVersion, "QGOV Client", shortGo, GOOS]
+//
+// shortGo is runtime.Version() truncated to go<major>.<minor> so the blob
+// stays within MaximumExtraDataSize (32) on linux/darwin/windows. If it still
+// exceeds the limit, the Go field is cleared (arity preserved) before giving up.
+// Non-empty extra is returned as-is unless it exceeds the size limit (then nil).
 func MakeExtraData(extra []byte) []byte {
 	if len(extra) == 0 {
-		extra, _ = rlp.EncodeToBytes([]interface{}{
-			uint(QVersionMajor<<16 | QVersionMinor<<8 | QVersionPatch),
-			"QGOV Client",
-			runtime.GOOS,
-		})
+		extra = encodeDefaultExtraData(shortGoVersion())
+		if uint64(len(extra)) > MaximumExtraDataSize {
+			extra = encodeDefaultExtraData("")
+		}
 	}
 	if uint64(len(extra)) > MaximumExtraDataSize {
 		log.Warn("Miner extra data exceed limit", "extra", hexutil.Bytes(extra), "limit", MaximumExtraDataSize)
 		return nil
 	}
 	return extra
+}
+
+func encodeDefaultExtraData(goTag string) []byte {
+	extra, _ := rlp.EncodeToBytes([]interface{}{
+		uint(QVersionMajor<<16 | QVersionMinor<<8 | QVersionPatch),
+		"QGOV Client",
+		goTag,
+		runtime.GOOS,
+	})
+	return extra
+}
+
+// shortGoVersion returns a bounded Go toolchain tag (e.g. "go1.26" from "go1.26.1")
+// so default vanity RLP fits Clique's 32-byte limit with the "QGOV Client" name.
+func shortGoVersion() string {
+	v := runtime.Version()
+	if !strings.HasPrefix(v, "go") {
+		return v
+	}
+	rest := strings.TrimPrefix(v, "go")
+	parts := strings.Split(rest, ".")
+	if len(parts) >= 2 {
+		return "go" + parts[0] + "." + parts[1]
+	}
+	return v
 }

--- a/params/extradata_test.go
+++ b/params/extradata_test.go
@@ -1,0 +1,55 @@
+package params
+
+import (
+	"runtime"
+	"testing"
+
+	"gitlab.com/q-dev/q-client/rlp"
+)
+
+type defaultExtraPayload struct {
+	Version uint
+	Name    string
+	OS      string
+}
+
+func TestMakeExtraDataDefault(t *testing.T) {
+	got := MakeExtraData(nil)
+	if len(got) == 0 {
+		t.Fatal("default extradata is empty")
+	}
+	if uint64(len(got)) > MaximumExtraDataSize {
+		t.Fatalf("default extradata len=%d exceeds MaximumExtraDataSize=%d", len(got), MaximumExtraDataSize)
+	}
+
+	var decoded defaultExtraPayload
+	if err := rlp.DecodeBytes(got, &decoded); err != nil {
+		t.Fatalf("decode default extradata: %v", err)
+	}
+
+	wantPacked := uint(QVersionMajor<<16 | QVersionMinor<<8 | QVersionPatch)
+	if decoded.Version != wantPacked {
+		t.Fatalf("packed version=%d want=%d", decoded.Version, wantPacked)
+	}
+	if decoded.Name != "QGOV Client" {
+		t.Fatalf("client name=%q want %q", decoded.Name, "QGOV Client")
+	}
+	if decoded.OS != runtime.GOOS {
+		t.Fatalf("os=%q want %q", decoded.OS, runtime.GOOS)
+	}
+}
+
+func TestMakeExtraDataOverride(t *testing.T) {
+	custom := []byte("custom-extra")
+	got := MakeExtraData(custom)
+	if string(got) != string(custom) {
+		t.Fatalf("override not preserved: %q", got)
+	}
+}
+
+func TestMakeExtraDataTooLong(t *testing.T) {
+	tooLong := make([]byte, MaximumExtraDataSize+1)
+	if got := MakeExtraData(tooLong); got != nil {
+		t.Fatalf("expected nil for oversized extradata, got len=%d", len(got))
+	}
+}

--- a/params/extradata_test.go
+++ b/params/extradata_test.go
@@ -2,6 +2,7 @@ package params
 
 import (
 	"runtime"
+	"strings"
 	"testing"
 
 	"gitlab.com/q-dev/q-client/rlp"
@@ -10,6 +11,7 @@ import (
 type defaultExtraPayload struct {
 	Version uint
 	Name    string
+	Go      string
 	OS      string
 }
 
@@ -37,6 +39,27 @@ func TestMakeExtraDataDefault(t *testing.T) {
 	if decoded.OS != runtime.GOOS {
 		t.Fatalf("os=%q want %q", decoded.OS, runtime.GOOS)
 	}
+	wantGo := shortGoVersion()
+	if decoded.Go != wantGo && decoded.Go != "" {
+		t.Fatalf("go tag=%q want %q or empty fallback", decoded.Go, wantGo)
+	}
+}
+
+func TestShortGoVersion(t *testing.T) {
+	got := shortGoVersion()
+	if !strings.HasPrefix(got, "go") {
+		t.Fatalf("shortGoVersion=%q missing go prefix", got)
+	}
+	full := runtime.Version()
+	if strings.Count(got, ".") > strings.Count(full, ".") {
+		t.Fatalf("shortGoVersion=%q longer than runtime.Version=%q", got, full)
+	}
+	// Prefer major.minor only when runtime reports a patch component.
+	if parts := strings.Split(strings.TrimPrefix(full, "go"), "."); len(parts) >= 3 {
+		if strings.Count(got, ".") != 1 {
+			t.Fatalf("shortGoVersion=%q want major.minor form from %q", got, full)
+		}
+	}
 }
 
 func TestMakeExtraDataOverride(t *testing.T) {
@@ -51,5 +74,23 @@ func TestMakeExtraDataTooLong(t *testing.T) {
 	tooLong := make([]byte, MaximumExtraDataSize+1)
 	if got := MakeExtraData(tooLong); got != nil {
 		t.Fatalf("expected nil for oversized extradata, got len=%d", len(got))
+	}
+}
+
+func TestEncodeDefaultExtraDataFitsCommonOS(t *testing.T) {
+	goTag := shortGoVersion()
+	for _, osName := range []string{"linux", "darwin", "windows"} {
+		extra, err := rlp.EncodeToBytes([]interface{}{
+			uint(QVersionMajor<<16 | QVersionMinor<<8 | QVersionPatch),
+			"QGOV Client",
+			goTag,
+			osName,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if uint64(len(extra)) > MaximumExtraDataSize {
+			t.Fatalf("os=%s go=%s len=%d exceeds %d", osName, goTag, len(extra), MaximumExtraDataSize)
+		}
 	}
 }

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	QVersionMajor = 2        // QGOV-Client major version component of the current release
 	QVersionMinor = 3        // QGOV-Client minor version component of the current release
-	QVersionPatch = 5        // QGOV-Client patch version component of the current release
+	QVersionPatch = 6        // QGOV-Client patch version component of the current release
 	QVersionMeta  = "stable" // QGOV-Client version metadata to append to the version string
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	QVersionMajor = 2        // QGOV-Client major version component of the current release
 	QVersionMinor = 3        // QGOV-Client minor version component of the current release
-	QVersionPatch = 4        // QGOV-Client patch version component of the current release
+	QVersionPatch = 5        // QGOV-Client patch version component of the current release
 	QVersionMeta  = "stable" // QGOV-Client version metadata to append to the version string
 )
 


### PR DESCRIPTION
## Summary

- Restore **4-field** default Clique vanity RLP so consumers (indexer-svc) can keep a single decoder shape.
- Fields: `[packedQVersion, "QGOV Client", shortGo, GOOS]` with `shortGo` = `go<major>.<minor>` (fits ≤32 on linux/darwin/windows).
- Fallback: clear Go tag if still oversized (preserve arity).
- Patch **2.3.6**.

Follow-up to #47. Related: [indexer-svc#3](https://gitlab.com/q-dev/indexer-svc/-/work_items/3) / [!81](https://gitlab.com/q-dev/indexer-svc/-/merge_requests/81).

Closes #49.

## Test plan

- [x] `go test ./params -run 'TestMakeExtraData|TestShortGo|TestEncodeDefault'`
- [ ] Seal a block and confirm vanity RLP has 4 elements / non-empty indexer `client_version` with legacy decoder